### PR TITLE
Fix TRM fetch using proxy

### DIFF
--- a/src/components/SelectCurrencyTRM/SelectCurrencyTRM.tsx
+++ b/src/components/SelectCurrencyTRM/SelectCurrencyTRM.tsx
@@ -24,13 +24,17 @@ export function SelectCurrencyTrm({
     const [loadingLatestTRM, setLoadingLatestTRM] = useState<boolean>(false);
     const [loadingTRMByDate, setLoadingTRMByDate] = useState<boolean>(false);
 
+    const TRM_BASE_URL = import.meta.env.DEV ? '/datos-gov' : 'https://www.datos.gov.co';
+
     const fetchLatestTRM = async () => {
         // Prevent multiple requests while loading
         if (loadingLatestTRM) return;
 
         try {
             setLoadingLatestTRM(true);
-            const response = await axios.get('https://www.datos.gov.co/resource/32sa-8pi3.json?$limit=1&$order=vigenciadesde DESC');
+            const response = await axios.get(
+                `${TRM_BASE_URL}/resource/32sa-8pi3.json?$limit=1&$order=vigenciadesde%20DESC`
+            );
             const trm = response.data[0].valor;
             setUsd2copState(trm);
             useCurrentUsd2Cop(Number(trm));
@@ -47,7 +51,9 @@ export function SelectCurrencyTrm({
 
         try {
             setLoadingTRMByDate(true);
-            const response = await axios.get(`https://www.datos.gov.co/resource/32sa-8pi3.json?vigenciadesde=${date}`);
+            const response = await axios.get(
+                `${TRM_BASE_URL}/resource/32sa-8pi3.json?vigenciadesde=${date}`
+            );
             if (response.data.length > 0) {
                 const trm = response.data[0].valor;
                 setUsd2copState(trm);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react'
 export default defineConfig(({ mode }) => {
   return {
     plugins: [react()],
+    server: {
+      proxy: {
+        '/datos-gov': {
+          target: 'https://www.datos.gov.co',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/datos-gov/, '')
+        }
+      }
+    },
     build: {
       outDir: 'dist',
       sourcemap: mode === 'development', // Keep source maps for development
@@ -12,6 +21,5 @@ export default defineConfig(({ mode }) => {
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode)
     }
-  }
-  })
-  
+  };
+});


### PR DESCRIPTION
## Summary
- use a proxy for TRM requests in `vite.config.ts`
- call the proxy path from `SelectCurrencyTRM`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68800ef5ea288332bd0735c384accd07