### PR TITLE
Add Cronograma Gantt demo

### DIFF
--- a/src/pages/Cronograma/CronogramaPage.tsx
+++ b/src/pages/Cronograma/CronogramaPage.tsx
@@ -1,12 +1,12 @@
 import { Container } from "@chakra-ui/react";
 import MyHeader from "../../components/MyHeader";
+import GanttDemo from "./GanttDemo";
 
 export default function CronogramaPage() {
     return (
         <Container minW={["auto", "container.lg", "container.xl"]} w="full" h="full">
             <MyHeader title="Cronograma" />
-            {/* Add your content here */}
-            <p>Página de Cronograma</p>
+            <GanttDemo />
         </Container>
     );
 }

--- a/src/pages/Cronograma/GanttDemo.tsx
+++ b/src/pages/Cronograma/GanttDemo.tsx
@@ -1,0 +1,59 @@
+import { Box } from "@chakra-ui/react";
+import { Gantt } from "wx-react-gantt";
+import "wx-react-gantt/dist/gantt.css";
+
+const tasks = [
+  {
+    id: 1,
+    text: "Base Neutra",
+    start: new Date(2024, 6, 22, 8),
+    end: new Date(2024, 6, 22, 16),
+    progress: 0,
+    type: "task",
+  },
+  {
+    id: 2,
+    text: "Semiterminados",
+    start: new Date(2024, 6, 22, 8),
+    end: new Date(2024, 6, 23, 12),
+    progress: 0,
+    type: "task",
+  },
+  {
+    id: 3,
+    text: "Envases con Termoencogible",
+    start: new Date(2024, 6, 23, 8),
+    end: new Date(2024, 6, 24, 12),
+    progress: 0,
+    type: "task",
+  },
+  {
+    id: 4,
+    text: "Producto Terminado",
+    start: new Date(2024, 6, 24, 14),
+    end: new Date(2024, 6, 25, 18),
+    progress: 0,
+    type: "task",
+  },
+  {
+    id: 5,
+    text: "Empaque y Despacho",
+    start: new Date(2024, 6, 25, 8),
+    end: new Date(2024, 6, 26, 12),
+    progress: 0,
+    type: "task",
+  },
+];
+
+const scales = [
+  { unit: "day", step: 1, format: "MMM dd" },
+  { unit: "hour", step: 4, format: "HH" },
+];
+
+export default function GanttDemo() {
+  return (
+    <Box w="full" h="500px">
+      <Gantt tasks={tasks} scales={scales} />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add mock Gantt chart demo using `wx-react-gantt`
- render Gantt demo on Cronograma page

## Testing
- `npm run lint` *(fails: React hooks rules and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_688139f3cf988332b4a90e8cb7108b86