### PR TITLE
Implement personal integrants search

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -73,6 +73,7 @@ export default class EndPointsURL{
 
     // integrantes de personal
     public save_integrante_personal: string;
+    public search_integrantes_personal: string;
 
     // bulk uploads por link
     public bulk_upload_proveedores: string;
@@ -185,6 +186,7 @@ export default class EndPointsURL{
 
         // integrantes de personal endpoints
         this.save_integrante_personal = `${domain}/${personal_res}/save`;
+        this.search_integrantes_personal = `${domain}/${personal_res}/search`;
 
         // contabilidad endpoints
         this.get_cuentas = `${domain}/${contabilidad_res}/cuentas`;

--- a/src/pages/ActivosFijos/Reportes/ListaOrdenesOCAF.tsx
+++ b/src/pages/ActivosFijos/Reportes/ListaOrdenesOCAF.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Box
+} from '@chakra-ui/react';
+import { OrdenCompraActivo, getEstadoOCAFText } from '../types';
+import { formatCOP } from '../../../utils/formatters';
+
+interface Props {
+    ordenes: OrdenCompraActivo[];
+}
+
+const ListaOrdenesOCAF: React.FC<Props> = ({ ordenes }) => {
+    return (
+        <Box overflowX="auto" mt={4}>
+            <Table variant="simple">
+                <Thead>
+                    <Tr>
+                        <Th>ID</Th>
+                        <Th>Fecha Emisión</Th>
+                        <Th>Fecha Vencimiento</Th>
+                        <Th>Proveedor</Th>
+                        <Th>Total a Pagar</Th>
+                        <Th>Estado</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {ordenes.map((orden) => (
+                        <Tr key={orden.ordenCompraActivoId}>
+                            <Td>{orden.ordenCompraActivoId}</Td>
+                            <Td>
+                                {orden.fechaEmision
+                                    ? new Date(orden.fechaEmision).toLocaleDateString()
+                                    : '-'}
+                            </Td>
+                            <Td>
+                                {orden.fechaVencimiento
+                                    ? new Date(orden.fechaVencimiento).toLocaleDateString()
+                                    : '-'}
+                            </Td>
+                            <Td>{orden.proveedor ? orden.proveedor.nombre : '-'}</Td>
+                            <Td>{formatCOP(orden.totalPagar)}</Td>
+                            <Td>{getEstadoOCAFText(orden.estado)}</Td>
+                        </Tr>
+                    ))}
+                </Tbody>
+            </Table>
+        </Box>
+    );
+};
+
+export default ListaOrdenesOCAF;

--- a/src/pages/ActivosFijos/Reportes/ReportesTabAF.tsx
+++ b/src/pages/ActivosFijos/Reportes/ReportesTabAF.tsx
@@ -1,22 +1,94 @@
-import {useState} from 'react';
-import {Flex} from '@chakra-ui/react';
-import {OrdenCompraActivos} from "../../Compras/types.tsx";
-import PdfGenerator from "../../Compras/pdfGenerator.tsx";
-
-// type Props = {};
+import { useState } from 'react';
+import { Container, Flex, Select, Button, Spinner } from '@chakra-ui/react';
+import axios from 'axios';
+import { format } from 'date-fns';
+import EndPointsURL from '../../../api/EndPointsURL';
+import DateRangePicker from '../../../components/DateRangePicker';
+import MyPagination from '../../../components/MyPagination';
+import { OrdenCompraActivo } from '../types';
+import ListaOrdenesOCAF from './ListaOrdenesOCAF';
 
 export function ReportesTabAf() {
+    const [listaOrdenes, setListaOrdenes] = useState<OrdenCompraActivo[]>([]);
+    const [date1, setDate1] = useState(format(new Date(), 'yyyy-MM-dd'));
+    const [date2, setDate2] = useState(format(new Date(), 'yyyy-MM-dd'));
+    const [estadoSearch, setEstadoSearch] = useState('0,1,2');
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(0);
+    const [loading, setLoading] = useState(false);
 
-    const generarPDF =
-        async (orden:OrdenCompraActivos) => {
+    const endPoints = new EndPointsURL();
 
-        const generator = new PdfGenerator();
-        await generator.generatePDF_OCA(orden);
-    }
+    const onClickBuscar = async (page = 0) => {
+        setLoading(true);
+        try {
+            const response = await axios.get(endPoints.search_ordenes_compra_activo, {
+                params: {
+                    date1,
+                    date2,
+                    estados: estadoSearch,
+                    page,
+                    size: 10,
+                },
+            });
+            const data = response.data;
+            setListaOrdenes(data.content);
+            setTotalPages(data.totalPages);
+            setCurrentPage(data.number);
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handlePageChange = (page: number) => {
+        onClickBuscar(page);
+    };
 
     return (
-        <Flex>
+        <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
+            <Flex direction="column" p="1em" gap="2">
+                <Flex direction="row" gap={2} align="center">
+                    <DateRangePicker
+                        date1={date1}
+                        setDate1={setDate1}
+                        date2={date2}
+                        setDate2={setDate2}
+                        flex_direction="column"
+                    />
+                    <Select
+                        value={estadoSearch}
+                        onChange={(e) => setEstadoSearch(e.target.value)}
+                        ml={4}
+                        width="200px"
+                    >
+                        <option value="0,1,2">Pendientes</option>
+                        <option value="3">Cerradas</option>
+                        <option value="-1">Canceladas</option>
+                        <option value="-1,0,1,2,3">Todas</option>
+                    </Select>
+                    <Button variant="solid" colorScheme="teal" onClick={() => onClickBuscar()}>
+                        Buscar
+                    </Button>
+                </Flex>
 
-        </Flex>
+                {loading ? (
+                    <Spinner mt={4} />
+                ) : (
+                    <>
+                        <ListaOrdenesOCAF ordenes={listaOrdenes} />
+                        <MyPagination
+                            page={currentPage}
+                            totalPages={totalPages}
+                            loading={loading}
+                            handlePageChange={handlePageChange}
+                        />
+                    </>
+                )}
+            </Flex>
+        </Container>
     );
 }
+
+export default ReportesTabAf;

--- a/src/pages/ActivosFijos/types.tsx
+++ b/src/pages/ActivosFijos/types.tsx
@@ -97,3 +97,12 @@ export interface OrdenCompraActivo {
     facturaCompraActivoId?: number;
     itemsOrdenCompra: ItemOrdenCompraActivo[];
 }
+
+export function getEstadoOCAFText(estado: number) {
+    if (estado === -1) return 'Cancelada';
+    if (estado === 0) return 'Pendiente liberacion';
+    if (estado === 1) return 'Pendiente envio';
+    if (estado === 2) return 'Pendiente recepcion';
+    if (estado === 3) return 'Cerrada exitosamente';
+    return '';
+}

--- a/src/pages/Personal/ConsultaDePersonal.tsx
+++ b/src/pages/Personal/ConsultaDePersonal.tsx
@@ -1,12 +1,76 @@
-import {useState} from 'react';
-import {Flex} from '@chakra-ui/react';
+import { useState } from 'react';
+import { Container, Flex, Input, Button, Spinner } from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import MyPagination from '../../components/MyPagination';
+import ListaIntegrantes from './ListaIntegrantes';
+import { IntegrantePersonal } from './types';
 
-type Props = {};
+export function ConsultaDePersonal() {
+    const [lista, setLista] = useState<IntegrantePersonal[]>([]);
+    const [searchText, setSearchText] = useState('');
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(0);
+    const [loading, setLoading] = useState(false);
 
-export function ConsultaDePersonal(props: Props) {
+    const endPoints = new EndPointsURL();
+
+    const onBuscar = async (page = 0) => {
+        setLoading(true);
+        try {
+            const response = await axios.get(endPoints.search_integrantes_personal, {
+                params: {
+                    q: searchText,
+                    page,
+                    size: 10,
+                },
+            });
+            const data = response.data;
+            setLista(data.content);
+            setTotalPages(data.totalPages);
+            setCurrentPage(data.number);
+        } catch (error) {
+            console.error(error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handlePageChange = (page: number) => {
+        onBuscar(page);
+    };
+
     return (
-        <Flex>
+        <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
+            <Flex direction="column" p="1em" gap="2">
+                <Flex direction="row" gap={2} align="center">
+                    <Input
+                        placeholder="Buscar por nombre o apellido"
+                        value={searchText}
+                        onChange={(e) => setSearchText(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') onBuscar();
+                        }}
+                    />
+                    <Button variant="solid" colorScheme="teal" onClick={() => onBuscar()}>
+                        Buscar
+                    </Button>
+                </Flex>
 
-        </Flex>
+                {loading ? (
+                    <Spinner mt={4} />
+                ) : (
+                    <>
+                        <ListaIntegrantes integrantes={lista} />
+                        <MyPagination
+                            page={currentPage}
+                            totalPages={totalPages}
+                            loading={loading}
+                            handlePageChange={handlePageChange}
+                        />
+                    </>
+                )}
+            </Flex>
+        </Container>
     );
 }

--- a/src/pages/Personal/ListaIntegrantes.tsx
+++ b/src/pages/Personal/ListaIntegrantes.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Box
+} from '@chakra-ui/react';
+import { IntegrantePersonal, getEstadoIntegranteText } from './types';
+
+interface Props {
+    integrantes: IntegrantePersonal[];
+}
+
+const ListaIntegrantes: React.FC<Props> = ({ integrantes }) => {
+    return (
+        <Box overflowX="auto" mt={4}>
+            <Table variant="simple">
+                <Thead>
+                    <Tr>
+                        <Th>ID</Th>
+                        <Th>Nombres</Th>
+                        <Th>Apellidos</Th>
+                        <Th>Departamento</Th>
+                        <Th>Estado</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {integrantes.map((intg) => (
+                        <Tr key={intg.id}>
+                            <Td>{intg.id}</Td>
+                            <Td>{intg.nombres}</Td>
+                            <Td>{intg.apellidos}</Td>
+                            <Td>{intg.departamento ?? '-'}</Td>
+                            <Td>{getEstadoIntegranteText(intg.estado)}</Td>
+                        </Tr>
+                    ))}
+                </Tbody>
+            </Table>
+        </Box>
+    );
+};
+
+export default ListaIntegrantes;

--- a/src/pages/Personal/types.tsx
+++ b/src/pages/Personal/types.tsx
@@ -55,3 +55,9 @@ export enum EstadoIntegrante {
     ACTIVO = 'ACTIVO',
     INACTIVO = 'INACTIVO'
 }
+
+export function getEstadoIntegranteText(estado?: EstadoIntegrante) {
+    if (estado === EstadoIntegrante.ACTIVO) return 'Activo';
+    if (estado === EstadoIntegrante.INACTIVO) return 'Inactivo';
+    return '';
+}


### PR DESCRIPTION
## Summary
- add endpoint url for searching personal members
- list personal integrants in a table
- implement search with pagination in ConsultaDePersonal
- helper to display status text

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: type errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884082937748332af1f2a8a711d733e