### PR TITLE
Implement dialogs for OCAF

### DIFF
--- a/src/pages/ActivosFijos/Reportes/DetailsOCAF.tsx
+++ b/src/pages/ActivosFijos/Reportes/DetailsOCAF.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalCloseButton,
+    ModalBody,
+    ModalFooter,
+    Button,
+    Box,
+    Text,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Tfoot
+} from '@chakra-ui/react';
+import { OrdenCompraActivo, getEstadoOCAFText } from '../types';
+import { formatCOP } from '../../../utils/formatters';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    orden: OrdenCompraActivo;
+}
+
+const DetailsOCAF: React.FC<Props> = ({ isOpen, onClose, orden }) => {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} size='xl' scrollBehavior='inside'>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Detalles Orden Compra AF</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <Box mb={4}>
+                        <Text><strong>ID:</strong> {orden.ordenCompraActivoId}</Text>
+                        <Text><strong>Fecha Emisión:</strong> {orden.fechaEmision ? new Date(orden.fechaEmision).toLocaleString() : '-'}</Text>
+                        <Text><strong>Fecha Vencimiento:</strong> {orden.fechaVencimiento ? new Date(orden.fechaVencimiento).toLocaleDateString() : '-'}</Text>
+                        <Text><strong>Proveedor:</strong> {orden.proveedor?.nombre ?? '-'}</Text>
+                        <Text><strong>Total a Pagar:</strong> {formatCOP(orden.totalPagar)}</Text>
+                        <Text><strong>Estado:</strong> {getEstadoOCAFText(orden.estado)}</Text>
+                        <Text><strong>Condición de Pago:</strong> {orden.condicionPago}</Text>
+                        <Text><strong>Tiempo de Entrega:</strong> {orden.tiempoEntrega}</Text>
+                        <Text><strong>Plazo de Pago:</strong> {orden.plazoPago}</Text>
+                    </Box>
+                    {orden.itemsOrdenCompra && orden.itemsOrdenCompra.length > 0 ? (
+                        <Table variant='simple' size='sm'>
+                            <Thead>
+                                <Tr>
+                                    <Th>ID</Th>
+                                    <Th>Descripción</Th>
+                                    <Th isNumeric>Cantidad</Th>
+                                    <Th isNumeric>Precio Unitario</Th>
+                                    <Th isNumeric>IVA</Th>
+                                    <Th isNumeric>Subtotal</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {orden.itemsOrdenCompra.map(item => (
+                                    <Tr key={item.itemOrdenId}>
+                                        <Td>{item.itemOrdenId}</Td>
+                                        <Td>{item.nombre}</Td>
+                                        <Td isNumeric>{item.cantidad}</Td>
+                                        <Td isNumeric>{formatCOP(item.precioUnitario)}</Td>
+                                        <Td isNumeric>{formatCOP(item.ivaValue)}</Td>
+                                        <Td isNumeric>{formatCOP(item.subTotal)}</Td>
+                                    </Tr>
+                                ))}
+                            </Tbody>
+                            <Tfoot>
+                                <Tr>
+                                    <Td colSpan={4} textAlign='right'><strong>SubTotal:</strong></Td>
+                                    <Td isNumeric colSpan={2}>{formatCOP(orden.subTotal)}</Td>
+                                </Tr>
+                                <Tr>
+                                    <Td colSpan={4} textAlign='right'><strong>IVA:</strong></Td>
+                                    <Td isNumeric colSpan={2}>{formatCOP(orden.iva)}</Td>
+                                </Tr>
+                                <Tr>
+                                    <Td colSpan={4} textAlign='right'><strong>Total a Pagar:</strong></Td>
+                                    <Td isNumeric colSpan={2}>{formatCOP(orden.totalPagar)}</Td>
+                                </Tr>
+                            </Tfoot>
+                        </Table>
+                    ) : (
+                        <Text>No hay items en esta orden.</Text>
+                    )}
+                </ModalBody>
+                <ModalFooter>
+                    <Button colorScheme='blue' mr={3} onClick={onClose}>Cerrar</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default DetailsOCAF;

--- a/src/pages/ActivosFijos/Reportes/Dialogs/DialogCancelarOCAF.tsx
+++ b/src/pages/ActivosFijos/Reportes/Dialogs/DialogCancelarOCAF.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalBody,
+    ModalFooter,
+    Button,
+    Text,
+    Input,
+    useToast
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../../../api/EndPointsURL';
+import { OrdenCompraActivo } from '../../types';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    orden: OrdenCompraActivo;
+    onOrdenCancelada?: () => void;
+}
+
+const DialogCancelarOCAF: React.FC<Props> = ({ isOpen, onClose, orden, onOrdenCancelada }) => {
+    const [randomCode, setRandomCode] = useState('');
+    const [inputCode, setInputCode] = useState('');
+    const toast = useToast();
+    const endpoints = new EndPointsURL();
+
+    useEffect(() => {
+        if (isOpen) {
+            const code = Math.floor(1000000 + Math.random() * 9000000).toString();
+            setRandomCode(code);
+            setInputCode('');
+        }
+    }, [isOpen]);
+
+    const handleCancelar = async () => {
+        if (inputCode !== randomCode) {
+            toast({
+                title: 'Código incorrecto',
+                description: 'El código ingresado no coincide.',
+                status: 'warning',
+                duration: 5000,
+                isClosable: true,
+            });
+            return;
+        }
+
+        try {
+            await axios.put(
+                endpoints.cancel_orden_compra_activo.replace('{ordenCompraActivoId}', String(orden.ordenCompraActivoId))
+            );
+            toast({
+                title: 'Orden cancelada',
+                description: 'La orden de compra fue cancelada correctamente.',
+                status: 'success',
+                duration: 5000,
+                isClosable: true,
+            });
+            if (onOrdenCancelada) onOrdenCancelada();
+        } catch (error) {
+            console.error(error);
+            toast({
+                title: 'Error',
+                description: 'No se pudo cancelar la orden.',
+                status: 'error',
+                duration: 5000,
+                isClosable: true,
+            });
+        } finally {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Confirmar Cancelación</ModalHeader>
+                <ModalBody>
+                    <Text mb={4}>
+                        Para confirmar la cancelación de la orden de compra, digite los 7 dígitos que ve a continuación y presione &quot;Cancelar Orden&quot;.
+                    </Text>
+                    <Text fontWeight="bold" mb={4}>Código: {randomCode}</Text>
+                    <Input
+                        placeholder="Ingrese el código"
+                        value={inputCode}
+                        onChange={(e) => setInputCode(e.target.value)}
+                    />
+                </ModalBody>
+                <ModalFooter>
+                    <Button colorScheme='red' mr={3} onClick={handleCancelar}>
+                        Cancelar Orden
+                    </Button>
+                    <Button variant='ghost' onClick={onClose}>Atrás</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default DialogCancelarOCAF;

--- a/src/pages/ActivosFijos/Reportes/Dialogs/DialogLiberarEnviarOCAF.tsx
+++ b/src/pages/ActivosFijos/Reportes/Dialogs/DialogLiberarEnviarOCAF.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalCloseButton,
+    ModalBody,
+    ModalFooter,
+    Button,
+    Box,
+    Text,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Input,
+    Select,
+    useToast,
+    VStack,
+    HStack
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../../../api/EndPointsURL';
+import { OrdenCompraActivo, getEstadoOCAFText } from '../../types';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    orden: OrdenCompraActivo;
+    onEstadoActualizado?: (orden: OrdenCompraActivo) => void;
+}
+
+enum TipoEnvio {
+    MANUAL = 'MANUAL',
+    EMAIL = 'EMAIL',
+    WHATSAPP = 'WHATSAPP'
+}
+
+const DialogLiberarEnviarOCAF: React.FC<Props> = ({ isOpen, onClose, orden, onEstadoActualizado }) => {
+    const [randomCode, setRandomCode] = useState('');
+    const [inputCode, setInputCode] = useState('');
+    const [tipoEnvio, setTipoEnvio] = useState<TipoEnvio>(TipoEnvio.MANUAL);
+    const [isLoading, setIsLoading] = useState(false);
+    const toast = useToast();
+
+    useEffect(() => {
+        if (isOpen) {
+            const code = Math.floor(1000 + Math.random() * 9000).toString();
+            setRandomCode(code);
+            setInputCode('');
+            if (hasEmail()) {
+                setTipoEnvio(TipoEnvio.EMAIL);
+            } else if (hasPhone()) {
+                setTipoEnvio(TipoEnvio.WHATSAPP);
+            } else {
+                setTipoEnvio(TipoEnvio.MANUAL);
+            }
+        }
+    }, [isOpen]);
+
+    const hasEmail = () => {
+        return orden.proveedor?.contactos?.some(c => c.email && c.email.trim() !== '') ?? false;
+    };
+
+    const hasPhone = () => {
+        return orden.proveedor?.contactos?.some(c => c.cel && c.cel.trim() !== '') ?? false;
+    };
+
+    const updateEstado = async (newEstado: number) => {
+        const formData = new FormData();
+        const requestData = newEstado === 2 ? { newEstado, tipoEnvio } : { newEstado };
+        formData.append('request', new Blob([JSON.stringify(requestData)], { type: 'application/json' }), 'request');
+        try {
+            const response = await axios.put(
+                `${EndPointsURL.getDomain()}/api/activos-fijos/ocaf/${orden.ordenCompraActivoId}/updateEstado`,
+                formData
+            );
+            if (onEstadoActualizado) onEstadoActualizado(response.data);
+            toast({
+                title: 'Estado actualizado',
+                status: 'success',
+                duration: 5000,
+                isClosable: true,
+            });
+        } catch (e) {
+            toast({
+                title: 'Error',
+                description: 'No se pudo actualizar el estado de la orden.',
+                status: 'error',
+                duration: 5000,
+                isClosable: true,
+            });
+        }
+    };
+
+    const handleLiberar = async () => {
+        if (inputCode === randomCode) {
+            await updateEstado(1);
+            onClose();
+        } else {
+            toast({
+                title: 'Código incorrecto',
+                status: 'warning',
+                duration: 5000,
+                isClosable: true,
+            });
+        }
+    };
+
+    const handleEnviar = async () => {
+        if (inputCode === randomCode) {
+            setIsLoading(true);
+            await updateEstado(2);
+            setIsLoading(false);
+            onClose();
+        } else {
+            toast({
+                title: 'Código incorrecto',
+                status: 'warning',
+                duration: 5000,
+                isClosable: true,
+            });
+        }
+    };
+
+    const renderDetails = () => (
+        <Box mb={4}>
+            <Text><strong>ID:</strong> {orden.ordenCompraActivoId}</Text>
+            <Text><strong>Fecha Emisión:</strong> {orden.fechaEmision ? new Date(orden.fechaEmision).toLocaleString() : '-'}</Text>
+            <Text><strong>Fecha Vencimiento:</strong> {orden.fechaVencimiento ? new Date(orden.fechaVencimiento).toLocaleDateString() : '-'}</Text>
+            <Text><strong>Proveedor:</strong> {orden.proveedor?.nombre ?? '-'}</Text>
+            <Text><strong>Total a Pagar:</strong> {orden.totalPagar}</Text>
+            <Text><strong>Estado:</strong> {getEstadoOCAFText(orden.estado)}</Text>
+            <Text><strong>Condición de Pago:</strong> {orden.condicionPago}</Text>
+            <Text><strong>Tiempo de Entrega:</strong> {orden.tiempoEntrega}</Text>
+            <Text><strong>Plazo de Pago:</strong> {orden.plazoPago}</Text>
+        </Box>
+    );
+
+    const renderItems = () => (
+        <Box>
+            {orden.itemsOrdenCompra && orden.itemsOrdenCompra.length > 0 && (
+                <Table variant='simple' size='sm'>
+                    <Thead>
+                        <Tr>
+                            <Th>ID</Th>
+                            <Th>Descripción</Th>
+                            <Th isNumeric>Cantidad</Th>
+                            <Th isNumeric>Precio Unitario</Th>
+                            <Th isNumeric>IVA</Th>
+                            <Th isNumeric>Subtotal</Th>
+                        </Tr>
+                    </Thead>
+                    <Tbody>
+                        {orden.itemsOrdenCompra.map(item => (
+                            <Tr key={item.itemOrdenId}>
+                                <Td>{item.itemOrdenId}</Td>
+                                <Td>{item.nombre}</Td>
+                                <Td isNumeric>{item.cantidad}</Td>
+                                <Td isNumeric>{item.precioUnitario}</Td>
+                                <Td isNumeric>{item.ivaValue}</Td>
+                                <Td isNumeric>{item.subTotal}</Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+            )}
+        </Box>
+    );
+
+    const renderContent = () => {
+        if (orden.estado === 0) {
+            return (
+                <>
+                    {renderDetails()}
+                    {renderItems()}
+                    <VStack mt={4} align='center'>
+                        <Text fontWeight='bold'>Código: {randomCode}</Text>
+                        <Input maxW='200px' value={inputCode} onChange={(e)=>setInputCode(e.target.value)} placeholder='Digite código'/>
+                        <Button colorScheme='green' onClick={handleLiberar}>Liberar Orden</Button>
+                    </VStack>
+                </>
+            );
+        }
+        if (orden.estado === 1) {
+            return (
+                <>
+                    {renderDetails()}
+                    {renderItems()}
+                    <VStack mt={4} align='center'>
+                        <Text fontWeight='bold'>Código: {randomCode}</Text>
+                        <HStack>
+                            <Select value={tipoEnvio} onChange={e=>setTipoEnvio(e.target.value as TipoEnvio)}>
+                                <option value={TipoEnvio.MANUAL}>{TipoEnvio.MANUAL}</option>
+                                {hasEmail() && <option value={TipoEnvio.EMAIL}>{TipoEnvio.EMAIL}</option>}
+                                {hasPhone() && <option value={TipoEnvio.WHATSAPP}>{TipoEnvio.WHATSAPP}</option>}
+                            </Select>
+                            <Input maxW='200px' value={inputCode} onChange={e=>setInputCode(e.target.value)} placeholder='Digite código'/>
+                            <Button colorScheme='green' onClick={handleEnviar} isLoading={isLoading} loadingText='Enviando'>Enviar a Proveedor</Button>
+                        </HStack>
+                    </VStack>
+                </>
+            );
+        }
+        return (
+            <Box textAlign='center' p='1em'>
+                <Text>La orden ya no se puede modificar.</Text>
+            </Box>
+        );
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} size={['auto','4xl']} scrollBehavior='inside'>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Actualizar Estado Orden Compra AF</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>{renderContent()}</ModalBody>
+                <ModalFooter>
+                    <Button colorScheme='blue' onClick={onClose}>Cerrar</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default DialogLiberarEnviarOCAF;


### PR DESCRIPTION
## Summary
- add dialog to cancel Orden de Compra Activo Fijo
- add dialog to liberate or send order to supplier
- create detail modal for Orden de Compra Activo Fijo
- integrate dialogs and detail view into OCAF report list with access level checks

## Testing
- `npx tsc -p tsconfig.json` *(fails: numerous errors)*
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688546fc1750833296a1913f2b186ec7