### PR TITLE
Add cliente management UI with CRUD operations

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -33,6 +33,12 @@ export default class EndPointsURL{
     public search_proveedores_pag :string;
     public update_proveedores:string;
 
+    // Clientes resource
+    public save_clientes:string;
+    public search_clientes:string;
+    public search_clientes_pag:string;
+    public update_clientes:string;
+
     // produccion resource
     public save_produccion:string;
     public search_ordenes_within_range:string;
@@ -153,6 +159,12 @@ export default class EndPointsURL{
         this.update_proveedores = `${domain}/${proveedores_res}/{id}`;
         this.bulk_upload_proveedores = `${domain}/api/bulk-upload/proveedores`;
         this.bulk_upload_productos = `${domain}/api/bulk-upload/products`;
+
+        // Clientes endpoints
+        this.save_clientes = `${domain}/clientes/save`;
+        this.search_clientes = `${domain}/clientes/search`;
+        this.search_clientes_pag = `${domain}/clientes/search_pag`;
+        this.update_clientes = `${domain}/clientes/{id}/with-files`;
 
         // compras endpoints
         this.byProveedorAndDate = `${domain}/${compras_res}/byProveedorAndDate`;

--- a/src/pages/Clientes/ClientesPage.tsx
+++ b/src/pages/Clientes/ClientesPage.tsx
@@ -1,25 +1,49 @@
-import React from 'react';
+import { useState, useEffect } from 'react';
 import { Container, Tabs, TabList, TabPanels, Tab, TabPanel } from "@chakra-ui/react";
 import MyHeader from "../../components/MyHeader.tsx";
 import { my_style_tab } from "../../styles/styles_general.tsx";
+import CodificarCliente from "./CodificarCliente.tsx";
+import { ConsultarClientes } from "./consultar/ConsultarClientes.tsx";
+import axios from 'axios';
+import EndPointsURL from "../../api/EndPointsURL.tsx";
+import { useAuth } from "../../context/AuthContext";
+import { Authority } from "../../api/global_types.tsx";
 
 const ClientesPage: React.FC = () => {
+    const [clientesAccessLevel,setClientesAccessLevel]=useState(0);
+    const {user}=useAuth();
+    const endPoints=new EndPointsURL();
+
+    useEffect(()=>{
+        const fetchLevel=async()=>{
+            try{
+                const resp=await axios.get(endPoints.whoami);
+                const auths:Authority[]=resp.data.authorities;
+                const cAuth=auths.find(a=>a.authority==='ACCESO_CLIENTES');
+                if(cAuth) setClientesAccessLevel(parseInt(cAuth.nivel));
+            }catch(e){console.error(e);}
+        };
+        fetchLevel();
+    },[]);
+
     return (
         <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
             <MyHeader title={'Gestión de Clientes'} />
             <Tabs isFitted gap="1em" variant="line">
                 <TabList>
-                    <Tab sx={my_style_tab}>Registrar Cliente</Tab>
+                    {(user==='master' || clientesAccessLevel>=2) && (
+                        <Tab sx={my_style_tab}>Registrar Cliente</Tab>
+                    )}
                     <Tab sx={my_style_tab}>Consultar Clientes</Tab>
                 </TabList>
                 <TabPanels>
+                    {(user==='master' || clientesAccessLevel>=2) && (
+                        <TabPanel>
+                            <CodificarCliente />
+                        </TabPanel>
+                    )}
                     <TabPanel>
-                        {/* Contenido para registrar clientes */}
-                        <p>Formulario de registro de clientes en desarrollo.</p>
-                    </TabPanel>
-                    <TabPanel>
-                        {/* Contenido para consultar clientes */}
-                        <p>Listado de clientes en desarrollo.</p>
+                        <ConsultarClientes />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/src/pages/Clientes/CodificarCliente.tsx
+++ b/src/pages/Clientes/CodificarCliente.tsx
@@ -1,0 +1,182 @@
+import { useState, useRef } from 'react';
+import {
+    Container,
+    FormControl,
+    FormLabel,
+    Input,
+    Button,
+    Grid,
+    GridItem,
+    VStack,
+    Textarea,
+    Icon,
+    useToast
+} from '@chakra-ui/react';
+import { FaFileCircleQuestion, FaFileCircleCheck } from 'react-icons/fa6';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL.tsx';
+import { ClienteFormData } from './types.tsx';
+
+const endPoints = new EndPointsURL();
+
+export default function CodificarCliente(){
+    const [formData, setFormData] = useState<ClienteFormData>({
+        nombre: '',
+        email: '',
+        telefono: '',
+        direccion: '',
+        condicionesPago: '',
+        limiteCredito: undefined
+    });
+    const [rutFile, setRutFile] = useState<File | null>(null);
+    const [camaraFile, setCamaraFile] = useState<File | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    const rutInputRef = useRef<HTMLInputElement>(null);
+    const camaraInputRef = useRef<HTMLInputElement>(null);
+    const toast = useToast();
+
+    const handleChange = (field: keyof ClienteFormData, value: any) => {
+        setFormData(prev => ({ ...prev, [field]: value }));
+    };
+
+    const validate = (): boolean => {
+        if(!formData.nombre.trim() || !formData.email.trim() || !formData.telefono.trim() || !formData.direccion.trim()){
+            toast({title:'Campos obligatorios', description:'Nombre, email, teléfono y dirección son requeridos', status:'warning', duration:4000, isClosable:true});
+            return false;
+        }
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if(!emailRegex.test(formData.email)){
+            toast({title:'Email inválido', status:'error', duration:4000, isClosable:true});
+            return false;
+        }
+        const phoneRegex = /^\+?\d{7,}$/;
+        if(!phoneRegex.test(formData.telefono)){
+            toast({title:'Teléfono inválido', status:'error', duration:4000, isClosable:true});
+            return false;
+        }
+        return true;
+    };
+
+    const handleRutChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if(file){
+            if(!file.name.toLowerCase().endsWith('.pdf')){
+                toast({title:'Solo PDF permitido', status:'error', duration:4000, isClosable:true});
+                e.target.value='';
+                return;
+            }
+            setRutFile(file);
+        }
+    };
+
+    const handleCamaraChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if(file){
+            if(!file.name.toLowerCase().endsWith('.pdf')){
+                toast({title:'Solo PDF permitido', status:'error', duration:4000, isClosable:true});
+                e.target.value='';
+                return;
+            }
+            setCamaraFile(file);
+        }
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if(!validate()) return;
+
+        const formDataToSend = new FormData();
+        formDataToSend.append('cliente', new Blob([JSON.stringify(formData)],{type:'application/json'}));
+        if(rutFile) formDataToSend.append('rutFile', rutFile);
+        if(camaraFile) formDataToSend.append('camaraFile', camaraFile);
+
+        try{
+            setLoading(true);
+            const resp = await axios.post(endPoints.save_clientes, formDataToSend, {headers:{'Content-Type':'multipart/form-data'}});
+            toast({title:'Cliente registrado', description:`Cliente ID ${resp.data.clienteId}`, status:'success', duration:5000, isClosable:true});
+            setFormData({nombre:'',email:'',telefono:'',direccion:'',condicionesPago:'',limiteCredito:undefined});
+            setRutFile(null); setCamaraFile(null);
+        }catch(err){
+            toast({title:'Error al registrar', status:'error', duration:5000, isClosable:true});
+        }finally{
+            setLoading(false);
+        }
+    };
+
+    const isFormValid = formData.nombre.trim() && formData.email.trim() && formData.telefono.trim() && formData.direccion.trim();
+
+    return (
+        <Container minW={['auto','container.lg','container.xl']} w='full' h='full'>
+            <form onSubmit={handleSubmit}>
+                <Grid templateColumns={['1fr','repeat(2,1fr)']} gap={4} p='1em' boxShadow='base'>
+                    <GridItem>
+                        <FormControl isRequired>
+                            <FormLabel>Nombre</FormLabel>
+                            <Input value={formData.nombre} onChange={e=>handleChange('nombre',e.target.value)} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl isRequired>
+                            <FormLabel>Email</FormLabel>
+                            <Input type='email' value={formData.email} onChange={e=>handleChange('email',e.target.value)} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl isRequired>
+                            <FormLabel>Teléfono</FormLabel>
+                            <Input value={formData.telefono} onChange={e=>handleChange('telefono',e.target.value)} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl isRequired>
+                            <FormLabel>Dirección</FormLabel>
+                            <Input value={formData.direccion} onChange={e=>handleChange('direccion',e.target.value)} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl>
+                            <FormLabel>Condiciones de Pago</FormLabel>
+                            <Input value={formData.condicionesPago||''} onChange={e=>handleChange('condicionesPago',e.target.value)} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl>
+                            <FormLabel>Límite de Crédito</FormLabel>
+                            <Input type='number' value={formData.limiteCredito||''} onChange={e=>handleChange('limiteCredito',Number(e.target.value))} />
+                        </FormControl>
+                    </GridItem>
+                    <GridItem colSpan={[1,2]}>
+                        <FormControl>
+                            <FormLabel>Observaciones</FormLabel>
+                            <Textarea value={''} isDisabled />
+                        </FormControl>
+                    </GridItem>
+                </Grid>
+                <Grid templateColumns={['1fr','repeat(2,1fr)']} gap={4} mt={6} p='1em' boxShadow='base'>
+                    <GridItem>
+                        <FormControl>
+                            <VStack spacing={4} align='center'>
+                                <FormLabel>RUT</FormLabel>
+                                <Icon as={rutFile ? FaFileCircleCheck : FaFileCircleQuestion} boxSize='4em' color={rutFile ? 'green' : 'orange.500'} />
+                                <Button onClick={()=>rutInputRef.current?.click()}>Browse</Button>
+                                <Input type='file' ref={rutInputRef} style={{display:'none'}} accept='application/pdf' onChange={handleRutChange}/>
+                            </VStack>
+                        </FormControl>
+                    </GridItem>
+                    <GridItem>
+                        <FormControl>
+                            <VStack spacing={4} align='center'>
+                                <FormLabel>Cámara y Comercio</FormLabel>
+                                <Icon as={camaraFile ? FaFileCircleCheck : FaFileCircleQuestion} boxSize='4em' color={camaraFile ? 'green' : 'orange.500'} />
+                                <Button onClick={()=>camaraInputRef.current?.click()}>Browse</Button>
+                                <Input type='file' ref={camaraInputRef} style={{display:'none'}} accept='application/pdf' onChange={handleCamaraChange}/>
+                            </VStack>
+                        </FormControl>
+                    </GridItem>
+                </Grid>
+                <Button type='submit' colorScheme='blue' mt={6} isLoading={loading} isDisabled={!isFormValid}>Registrar Cliente</Button>
+            </form>
+        </Container>
+    );
+}

--- a/src/pages/Clientes/consultar/ConsultarClientes.tsx
+++ b/src/pages/Clientes/consultar/ConsultarClientes.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import PanelBusqueda from './PanelBusqueda.tsx';
+import { DetalleCliente } from './DetalleCliente.tsx';
+import { Cliente } from '../types.tsx';
+
+export function ConsultarClientes(){
+    const [estado,setEstado]=useState(0); //0 lista,1 detalle
+    const [clienteSeleccionado,setClienteSeleccionado]=useState<Cliente>();
+
+    const Conditional=()=>{
+        if(estado===0){
+            return <PanelBusqueda setEstado={setEstado} setClienteSeleccionado={setClienteSeleccionado}/>;
+        }
+        if(estado===1 && clienteSeleccionado){
+            return <DetalleCliente cliente={clienteSeleccionado} setEstado={setEstado} setClienteSeleccionado={setClienteSeleccionado} refreshSearch={()=>setEstado(0)} />;
+        }
+    };
+
+    return <Conditional/>;
+}

--- a/src/pages/Clientes/consultar/DetalleCliente.tsx
+++ b/src/pages/Clientes/consultar/DetalleCliente.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useRef } from 'react';
+import {
+    Box, Button, Flex, Heading, Text, VStack, Grid, GridItem,
+    FormControl, FormLabel, Input, Icon, HStack, useToast
+} from '@chakra-ui/react';
+import { ArrowBackIcon, EditIcon } from '@chakra-ui/icons';
+import { FaFileCircleQuestion, FaFileCircleCheck } from 'react-icons/fa6';
+import axios from 'axios';
+import EndPointsURL from '../../../api/EndPointsURL.tsx';
+import { Cliente } from '../types.tsx';
+import { useAuth } from '../../../context/AuthContext';
+import { Authority } from '../../../api/global_types.tsx';
+
+interface Props{
+    cliente: Cliente;
+    setEstado:(estado:number)=>void;
+    setClienteSeleccionado?: (c:Cliente)=>void;
+    refreshSearch?: ()=>void;
+}
+
+export function DetalleCliente({cliente,setEstado,setClienteSeleccionado,refreshSearch}:Props){
+    const [editMode,setEditMode] = useState(false);
+    const [clienteData,setClienteData] = useState<Cliente>({...cliente});
+    const [clientesAccessLevel,setClientesAccessLevel]=useState(0);
+    const [rutFile,setRutFile] = useState<File|null>(null);
+    const [camaraFile,setCamaraFile] = useState<File|null>(null);
+    const rutInputRef = useRef<HTMLInputElement>(null);
+    const camaraInputRef = useRef<HTMLInputElement>(null);
+    const toast = useToast();
+    const endPoints = new EndPointsURL();
+    const {user} = useAuth();
+
+    useEffect(()=>{
+        const fetchLevel = async ()=>{
+            try{
+                const resp = await axios.get(endPoints.whoami);
+                const auths:Authority[] = resp.data.authorities;
+                const cAuth = auths.find(a=>a.authority==='ACCESO_CLIENTES');
+                if(cAuth) setClientesAccessLevel(parseInt(cAuth.nivel));
+            }catch(e){ console.error(e); }
+        };
+        fetchLevel();
+    },[]);
+
+    const handleBack=()=>{
+        setEstado(0);
+        refreshSearch && refreshSearch();
+    };
+
+    const handleInputChange = (field: keyof Cliente, value:any)=>{
+        setClienteData(prev=>({...prev,[field]:value}));
+    };
+
+    const validate = ():boolean=>{
+        if(!clienteData.nombre.trim() || !clienteData.email.trim() || !clienteData.telefono.trim() || !clienteData.direccion.trim()){
+            toast({title:'Campos requeridos',status:'warning',duration:4000,isClosable:true});
+            return false;
+        }
+        const emailRegex=/^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if(!emailRegex.test(clienteData.email)){
+            toast({title:'Email inválido',status:'error',duration:4000,isClosable:true});
+            return false;
+        }
+        const phoneRegex=/^\+?\d{7,}$/;
+        if(!phoneRegex.test(clienteData.telefono)){
+            toast({title:'Teléfono inválido',status:'error',duration:4000,isClosable:true});
+            return false;
+        }
+        return true;
+    };
+
+    const handleRutChange=(e:React.ChangeEvent<HTMLInputElement>)=>{
+        const file=e.target.files?.[0];
+        if(file){
+            if(!file.name.toLowerCase().endsWith('.pdf')){
+                toast({title:'Solo PDF permitido',status:'error',duration:4000,isClosable:true});
+                e.target.value='';
+                return;
+            }
+            setRutFile(file);
+        }
+    };
+
+    const handleCamaraChange=(e:React.ChangeEvent<HTMLInputElement>)=>{
+        const file=e.target.files?.[0];
+        if(file){
+            if(!file.name.toLowerCase().endsWith('.pdf')){
+                toast({title:'Solo PDF permitido',status:'error',duration:4000,isClosable:true});
+                e.target.value='';
+                return;
+            }
+            setCamaraFile(file);
+        }
+    };
+
+    const handleSaveChanges=async()=>{
+        if(!validate()) return;
+        try{
+            const formData = new FormData();
+            formData.append('cliente', new Blob([JSON.stringify(clienteData)],{type:'application/json'}));
+            if(rutFile) formData.append('rutFile', rutFile);
+            if(camaraFile) formData.append('camaraFile', camaraFile);
+            const url = endPoints.update_clientes.replace('{id}', clienteData.clienteId.toString());
+            const resp = await axios.put(url, formData,{headers:{'Content-Type':'multipart/form-data'}});
+            toast({title:'Cliente actualizado',status:'success',duration:5000,isClosable:true});
+            setEditMode(false);
+            setClienteData(resp.data);
+            setRutFile(null); setCamaraFile(null);
+            setClienteSeleccionado && setClienteSeleccionado(resp.data);
+        }catch(e){
+            console.error(e);
+            toast({title:'Error al actualizar',status:'error',duration:5000,isClosable:true});
+        }
+    };
+
+    const canEdit = user==='master' || clientesAccessLevel>=3;
+
+    return (
+        <Box p={5} bg='white' borderRadius='md' boxShadow='base'>
+            <Flex justifyContent='space-between' alignItems='center' mb={5}>
+                <Button leftIcon={<ArrowBackIcon />} colorScheme='blue' variant='outline' onClick={handleBack}>Regresar</Button>
+                <Heading size='lg'>Detalle del Cliente</Heading>
+                {canEdit && !editMode && (
+                    <Button leftIcon={<EditIcon />} colorScheme='green' onClick={()=>setEditMode(true)}>Editar</Button>
+                )}
+                {editMode && (
+                    <HStack>
+                        <Button colorScheme='red' variant='outline' onClick={()=>{setEditMode(false);setClienteData({...cliente});setRutFile(null);setCamaraFile(null);}}>Cancelar</Button>
+                        <Button colorScheme='green' onClick={handleSaveChanges}>Guardar</Button>
+                    </HStack>
+                )}
+            </Flex>
+            <Grid templateColumns='repeat(2,1fr)' gap={6}>
+                <GridItem>
+                    <VStack align='start' spacing={3}>
+                        <Box>
+                            <Text fontWeight='bold'>Nombre:</Text>
+                            {editMode ? <Input value={clienteData.nombre} onChange={e=>handleInputChange('nombre',e.target.value)} /> : <Text>{cliente.nombre}</Text>}
+                        </Box>
+                        <Box>
+                            <Text fontWeight='bold'>Email:</Text>
+                            {editMode ? <Input value={clienteData.email} onChange={e=>handleInputChange('email',e.target.value)} /> : <Text>{cliente.email}</Text>}
+                        </Box>
+                        <Box>
+                            <Text fontWeight='bold'>Teléfono:</Text>
+                            {editMode ? <Input value={clienteData.telefono} onChange={e=>handleInputChange('telefono',e.target.value)} /> : <Text>{cliente.telefono}</Text>}
+                        </Box>
+                        <Box>
+                            <Text fontWeight='bold'>Dirección:</Text>
+                            {editMode ? <Input value={clienteData.direccion} onChange={e=>handleInputChange('direccion',e.target.value)} /> : <Text>{cliente.direccion}</Text>}
+                        </Box>
+                    </VStack>
+                </GridItem>
+                <GridItem>
+                    <VStack align='start' spacing={3}>
+                        <Box>
+                            <Text fontWeight='bold'>Condiciones de Pago:</Text>
+                            {editMode ? <Input value={clienteData.condicionesPago||''} onChange={e=>handleInputChange('condicionesPago',e.target.value)} /> : <Text>{cliente.condicionesPago||'-'}</Text>}
+                        </Box>
+                        <Box>
+                            <Text fontWeight='bold'>Límite de Crédito:</Text>
+                            {editMode ? <Input type='number' value={clienteData.limiteCredito||''} onChange={e=>handleInputChange('limiteCredito',Number(e.target.value))} /> : <Text>{cliente.limiteCredito||'-'}</Text>}
+                        </Box>
+                    </VStack>
+                </GridItem>
+            </Grid>
+            {editMode && (
+                <Grid templateColumns='repeat(2,1fr)' gap={6} mt={6}>
+                    <GridItem>
+                        <VStack spacing={4} align='center'>
+                            <FormLabel>RUT</FormLabel>
+                            <Icon as={rutFile ? FaFileCircleCheck : FaFileCircleQuestion} boxSize='4em' color={rutFile ? 'green' : 'orange.500'} />
+                            <Button onClick={()=>rutInputRef.current?.click()}>Seleccionar archivo</Button>
+                            <Input type='file' ref={rutInputRef} style={{display:'none'}} accept='application/pdf' onChange={handleRutChange}/>
+                            {rutFile && <Text>{rutFile.name}</Text>}
+                        </VStack>
+                    </GridItem>
+                    <GridItem>
+                        <VStack spacing={4} align='center'>
+                            <FormLabel>Cámara y Comercio</FormLabel>
+                            <Icon as={camaraFile ? FaFileCircleCheck : FaFileCircleQuestion} boxSize='4em' color={camaraFile ? 'green' : 'orange.500'} />
+                            <Button onClick={()=>camaraInputRef.current?.click()}>Seleccionar archivo</Button>
+                            <Input type='file' ref={camaraInputRef} style={{display:'none'}} accept='application/pdf' onChange={handleCamaraChange}/>
+                            {camaraFile && <Text>{camaraFile.name}</Text>}
+                        </VStack>
+                    </GridItem>
+                </Grid>
+            )}
+        </Box>
+    );
+}

--- a/src/pages/Clientes/consultar/PanelBusqueda.tsx
+++ b/src/pages/Clientes/consultar/PanelBusqueda.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import {
+    Flex, FormControl, FormLabel, Input, Button, Box, Select, useToast
+} from '@chakra-ui/react';
+import MyPagination from '../../../components/MyPagination.tsx';
+import { ListaSearchClientes } from './panel_busqueda_comp/ListaSearchClientes.tsx';
+import axios from 'axios';
+import EndPointsURL from '../../../api/EndPointsURL.tsx';
+import { Cliente, DTO_SearchCliente, SearchType } from '../types.tsx';
+
+interface Props{
+    setEstado: (estado:number)=>void;
+    setClienteSeleccionado: (c:Cliente)=>void;
+}
+
+export default function PanelBusqueda({setEstado, setClienteSeleccionado}:Props){
+    const [searchType, setSearchType] = useState<SearchType>(SearchType.ID);
+    const [id, setId] = useState('');
+    const [nombre, setNombre] = useState('');
+    const [email, setEmail] = useState('');
+    const [clientes, setClientes] = useState<Cliente[]>([]);
+    const [page, setPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(1);
+    const [loading, setLoading] = useState(false);
+    const endPoints = new EndPointsURL();
+    const toast = useToast();
+    const pageSize = 10;
+
+    const handleSearch = async (pageNumber:number) => {
+        setLoading(true);
+        setPage(pageNumber);
+        try{
+            const dto: DTO_SearchCliente = {
+                id: searchType===SearchType.ID? Number(id) : null,
+                nombre: searchType===SearchType.NOMBRE_O_EMAIL? nombre||null : null,
+                email: searchType===SearchType.NOMBRE_O_EMAIL? email||null : null,
+                searchType
+            };
+            const resp = await axios.post(endPoints.search_clientes_pag, dto, {params:{page:pageNumber,size:pageSize}});
+            setClientes(resp.data.content);
+            setTotalPages(resp.data.totalPages);
+        }catch(err){
+            toast({title:'Error al buscar', status:'error', duration:4000, isClosable:true});
+            setClientes([]); setTotalPages(1);
+        }finally{
+            setLoading(false);
+        }
+    };
+
+    const verDetalle = (c:Cliente)=>{
+        setClienteSeleccionado(c);
+        setEstado(1);
+    };
+
+    return (
+        <Flex direction='column' p={4}>
+            <Box p={4} borderWidth='1px' borderRadius='lg' mb={4}>
+                {searchType===SearchType.ID ? (
+                    <FormControl mb={4}>
+                        <FormLabel>ID Cliente</FormLabel>
+                        <Input value={id} onChange={e=>setId(e.target.value)} />
+                    </FormControl>
+                ) : (
+                    <>
+                        <FormControl mb={4}>
+                            <FormLabel>Nombre</FormLabel>
+                            <Input value={nombre} onChange={e=>setNombre(e.target.value)} />
+                        </FormControl>
+                        <FormControl mb={4}>
+                            <FormLabel>Email</FormLabel>
+                            <Input value={email} onChange={e=>setEmail(e.target.value)} />
+                        </FormControl>
+                    </>
+                )}
+                <Flex gap={4} align='center'>
+                    <FormControl flex={1}>
+                        <FormLabel>Tipo de búsqueda</FormLabel>
+                        <Select value={searchType} onChange={e=>setSearchType(e.target.value as SearchType)}>
+                            <option value={SearchType.ID}>ID</option>
+                            <option value={SearchType.NOMBRE_O_EMAIL}>Nombre o Email</option>
+                        </Select>
+                    </FormControl>
+                    <Button colorScheme='blue' onClick={()=>handleSearch(0)} isLoading={loading} flex={1} mt={6}>Buscar</Button>
+                </Flex>
+            </Box>
+            <Box mb={4}>
+                <ListaSearchClientes clientes={clientes} onVerDetalle={verDetalle}/>
+            </Box>
+            {totalPages>1 && (
+                <MyPagination page={page} totalPages={totalPages} loading={loading} handlePageChange={handleSearch}/>
+            )}
+        </Flex>
+    );
+}

--- a/src/pages/Clientes/consultar/panel_busqueda_comp/ListaSearchClientes.tsx
+++ b/src/pages/Clientes/consultar/panel_busqueda_comp/ListaSearchClientes.tsx
@@ -1,0 +1,40 @@
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Text } from '@chakra-ui/react';
+import { Cliente } from '../../types.tsx';
+
+interface Props{
+    clientes: Cliente[];
+    onVerDetalle?: (c:Cliente)=>void;
+}
+
+export function ListaSearchClientes({clientes,onVerDetalle}:Props){
+    return (
+        <Box overflowX='auto' width='100%'>
+            <Table variant='simple' size='sm'>
+                <Thead>
+                    <Tr>
+                        <Th>ID</Th>
+                        <Th>Nombre</Th>
+                        <Th>Email</Th>
+                        <Th>Teléfono</Th>
+                        <Th>Ver Detalle</Th>
+                    </Tr>
+                </Thead>
+                <Tbody>
+                    {clientes.length===0 ? (
+                        <Tr><Td colSpan={5} textAlign='center'><Text py={4}>No se encontraron clientes.</Text></Td></Tr>
+                    ) : (
+                        clientes.map(c=> (
+                            <Tr key={c.clienteId} _hover={{bg:'gray.100'}}>
+                                <Td>{c.clienteId}</Td>
+                                <Td>{c.nombre}</Td>
+                                <Td>{c.email}</Td>
+                                <Td>{c.telefono}</Td>
+                                <Td><Button size='sm' colorScheme='blue' onClick={()=>onVerDetalle&&onVerDetalle(c)}>Ver Detalle</Button></Td>
+                            </Tr>
+                        ))
+                    )}
+                </Tbody>
+            </Table>
+        </Box>
+    );
+}

--- a/src/pages/Clientes/types.tsx
+++ b/src/pages/Clientes/types.tsx
@@ -1,21 +1,32 @@
-// src/pages/Clientes/types.tsx
-
 export interface Cliente {
-    id: number;
+    clienteId: number;
     nombre: string;
-    ruc?: string;
-    direccion?: string;
-    telefono?: string;
-    email?: string;
-    contacto?: string;
-    estado: number; // 1: activo, 0: inactivo
+    email: string;
+    telefono: string;
+    direccion: string;
+    condicionesPago?: string;
+    limiteCredito?: number;
+    urlRut?: string;
+    urlCamComer?: string;
 }
 
 export interface ClienteFormData {
     nombre: string;
-    ruc?: string;
-    direccion?: string;
-    telefono?: string;
-    email?: string;
-    contacto?: string;
+    email: string;
+    telefono: string;
+    direccion: string;
+    condicionesPago?: string;
+    limiteCredito?: number;
+}
+
+export interface DTO_SearchCliente {
+    id: number | null;
+    nombre: string | null;
+    email: string | null;
+    searchType: SearchType;
+}
+
+export enum SearchType {
+    ID = 'ID',
+    NOMBRE_O_EMAIL = 'NOMBRE_O_EMAIL'
 }


### PR DESCRIPTION
## Summary
- implement client CRUD pages mimicking proveedores functionality
- add client endpoints to EndPointsURL
- add comprehensive cliente types
- create forms and detail views with validation and file upload

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint-plugin-storybook)*

------
https://chatgpt.com/codex/tasks/task_e_6888142d3f6c8332b2d5a19949a7b8a0