### PR TITLE
refactor productos navigation with card-based sections

### DIFF
--- a/src/pages/Productos/BasicOperationsTabs.tsx
+++ b/src/pages/Productos/BasicOperationsTabs.tsx
@@ -1,0 +1,45 @@
+import {useState} from 'react';
+import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/react';
+import {FaArrowLeft} from 'react-icons/fa';
+import CodificarMaterialesTab from './CodificarMaterialesTab';
+import InformeProductosTab from './InformeProductosTab';
+import {my_style_tab} from '../../styles/styles_general.tsx';
+
+interface Props {
+    user: string | null;
+    productosAccessLevel: number;
+    onBack: () => void;
+}
+
+export function BasicOperationsTabs({user, productosAccessLevel, onBack}: Props) {
+    const [tabIndex, setTabIndex] = useState(0);
+
+    return (
+        <Flex direction={'column'} gap={4} w="full" h="full">
+            <Button leftIcon={<FaArrowLeft />} w="fit-content" onClick={onBack}>
+                Volver
+            </Button>
+            <Tabs isFitted gap="1em" variant="line" index={tabIndex} onChange={setTabIndex}>
+                <TabList>
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <Tab sx={my_style_tab}>Codificar Material</Tab>
+                    )}
+                    <Tab sx={my_style_tab}>Consulta</Tab>
+                </TabList>
+
+                <TabPanels>
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <TabPanel>
+                            <CodificarMaterialesTab />
+                        </TabPanel>
+                    )}
+                    <TabPanel>
+                        <InformeProductosTab />
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
+        </Flex>
+    );
+}
+
+export default BasicOperationsTabs;

--- a/src/pages/Productos/DefinicionProcesosTabs.tsx
+++ b/src/pages/Productos/DefinicionProcesosTabs.tsx
@@ -1,0 +1,30 @@
+import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/react';
+import {FaArrowLeft} from 'react-icons/fa';
+import DefinicionProcesosTab from './DefinicionProcesosTab';
+import {my_style_tab} from '../../styles/styles_general.tsx';
+
+interface Props {
+    onBack: () => void;
+}
+
+export function DefinicionProcesosTabs({onBack}: Props) {
+    return (
+        <Flex direction={'column'} gap={4} w="full" h="full">
+            <Button leftIcon={<FaArrowLeft />} w="fit-content" onClick={onBack}>
+                Volver
+            </Button>
+            <Tabs isFitted gap="1em" variant="line">
+                <TabList>
+                    <Tab sx={my_style_tab}>Definición de Procesos</Tab>
+                </TabList>
+                <TabPanels>
+                    <TabPanel>
+                        <DefinicionProcesosTab />
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
+        </Flex>
+    );
+}
+
+export default DefinicionProcesosTabs;

--- a/src/pages/Productos/ProductosMenuSelection.tsx
+++ b/src/pages/Productos/ProductosMenuSelection.tsx
@@ -1,0 +1,99 @@
+import {Card, CardBody, CardHeader, Flex, Heading, Icon, SimpleGrid, Text} from '@chakra-ui/react';
+import {FaTools, FaBoxOpen, FaCogs} from 'react-icons/fa';
+
+interface Props {
+    setViewMode: (mode: 'menu' | 'basic' | 'terminados' | 'procesos') => void;
+    user: string | null;
+    productosAccessLevel: number;
+}
+
+export function ProductosMenuSelection({setViewMode, user, productosAccessLevel}: Props) {
+    return (
+        <Flex direction={"column"} gap={10} w="full">
+            <Heading as="h2" size="lg" textAlign="center" mb={6} fontFamily="Arimo">
+                Seleccione una opción
+            </Heading>
+
+            <SimpleGrid columns={3} spacing={8} w="full">
+                {/* Basic Operations card */}
+                <Card
+                    h="250px"
+                    cursor="pointer"
+                    bg="orange.100"
+                    _hover={{
+                        bg: "orange.300",
+                        transform: "translateY(-5px)",
+                        boxShadow: "xl",
+                    }}
+                    _active={{ bg: "orange.800", color: "white" }}
+                    transition="all 0.3s ease"
+                    onClick={() => setViewMode('basic')}
+                >
+                    <CardHeader borderBottom="0.1em solid" p={4}>
+                        <Heading as="h3" size="md" fontFamily="Comfortaa Variable">
+                            Basic Operations
+                        </Heading>
+                    </CardHeader>
+                    <CardBody display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={6}>
+                        <Icon as={FaTools} boxSize="5em" mb={4} />
+                        <Text textAlign="center">Codificar material y consultar productos</Text>
+                    </CardBody>
+                </Card>
+
+                {/* Definicion Terminados/Semiterminados card */}
+                <Card
+                    h="250px"
+                    cursor="pointer"
+                    bg="teal.100"
+                    _hover={{
+                        bg: "teal.300",
+                        transform: "translateY(-5px)",
+                        boxShadow: "xl",
+                    }}
+                    _active={{ bg: "teal.800", color: "white" }}
+                    transition="all 0.3s ease"
+                    onClick={() => setViewMode('terminados')}
+                >
+                    <CardHeader borderBottom="0.1em solid" p={4}>
+                        <Heading as="h3" size="md" fontFamily="Comfortaa Variable">
+                            Definición Terminados/Semiterminados
+                        </Heading>
+                    </CardHeader>
+                    <CardBody display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={6}>
+                        <Icon as={FaBoxOpen} boxSize="5em" mb={4} />
+                        <Text textAlign="center">Gestionar terminados, semiterminados y familias</Text>
+                    </CardBody>
+                </Card>
+
+                {/* Definicion Procesos card, only for privileged users */}
+                {(user === 'master' || productosAccessLevel >= 2) && (
+                    <Card
+                        h="250px"
+                        cursor="pointer"
+                        bg="purple.100"
+                        _hover={{
+                            bg: "purple.300",
+                            transform: "translateY(-5px)",
+                            boxShadow: "xl",
+                        }}
+                        _active={{ bg: "purple.800", color: "white" }}
+                        transition="all 0.3s ease"
+                        onClick={() => setViewMode('procesos')}
+                    >
+                        <CardHeader borderBottom="0.1em solid" p={4}>
+                            <Heading as="h3" size="md" fontFamily="Comfortaa Variable">
+                                Definición de Procesos
+                            </Heading>
+                        </CardHeader>
+                        <CardBody display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={6}>
+                            <Icon as={FaCogs} boxSize="5em" mb={4} />
+                            <Text textAlign="center">Definir procesos de producción</Text>
+                        </CardBody>
+                    </Card>
+                )}
+            </SimpleGrid>
+        </Flex>
+    );
+}
+
+export default ProductosMenuSelection;

--- a/src/pages/Productos/TerminadosSemiterminadosTabs.tsx
+++ b/src/pages/Productos/TerminadosSemiterminadosTabs.tsx
@@ -1,0 +1,54 @@
+import {useState} from 'react';
+import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/react';
+import {FaArrowLeft} from 'react-icons/fa';
+import CodificarSemioTermiTab from './CodificarSemioTermiTab/CodificarSemioTermiTab';
+import {FamiliasTab} from './FamiliasTab';
+import InformeProductosTab from './InformeProductosTab';
+import {my_style_tab} from '../../styles/styles_general.tsx';
+
+interface Props {
+    user: string | null;
+    productosAccessLevel: number;
+    onBack: () => void;
+}
+
+export function TerminadosSemiterminadosTabs({user, productosAccessLevel, onBack}: Props) {
+    const [tabIndex, setTabIndex] = useState(0);
+
+    return (
+        <Flex direction={'column'} gap={4} w="full" h="full">
+            <Button leftIcon={<FaArrowLeft />} w="fit-content" onClick={onBack}>
+                Volver
+            </Button>
+            <Tabs isFitted gap="1em" variant="line" index={tabIndex} onChange={setTabIndex}>
+                <TabList>
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <Tab sx={my_style_tab}>Codificar Terminado/Semiterminado</Tab>
+                    )}
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <Tab sx={my_style_tab}>Familias</Tab>
+                    )}
+                    <Tab sx={my_style_tab}>Consulta</Tab>
+                </TabList>
+
+                <TabPanels>
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <TabPanel>
+                            <CodificarSemioTermiTab isActive={tabIndex === 0} />
+                        </TabPanel>
+                    )}
+                    {(user === 'master' || productosAccessLevel >= 2) && (
+                        <TabPanel>
+                            <FamiliasTab />
+                        </TabPanel>
+                    )}
+                    <TabPanel>
+                        <InformeProductosTab />
+                    </TabPanel>
+                </TabPanels>
+            </Tabs>
+        </Flex>
+    );
+}
+
+export default TerminadosSemiterminadosTabs;


### PR DESCRIPTION
## Summary
- replace crowded tab layout in Productos with three-card menu using color-coded icons and hover effects
- add dedicated tab groups for basic operations and terminados/semiterminados, keeping Consulta available in both
- introduce standalone procesos tab container and state-based navigation between menu and sections

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 117 problems)*
- `npm run build` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f96c629688332a152c3fe606af005