### PR TITLE
feat(productos): add production resource tab and form

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -47,6 +47,9 @@ export default class EndPointsURL{
     public orden_produccion_update_estado:string;
     public search_ordenes_by_responsable:string;
 
+    // recursos de produccion
+    public save_recurso_produccion:string;
+
 
     // compras resource
     public byProveedorAndDate:string;
@@ -131,6 +134,7 @@ export default class EndPointsURL{
         const contabilidad_res = 'api/contabilidad';
         const auth_res = 'api/auth';
         const personal_res = 'integrantes-personal';
+        const recursos_produccion_res = 'api/recursos-produccion';
 
         // productos endpoints
         this.search_mprima = `${domain}/${productos_res}/search_mprima`;
@@ -181,6 +185,9 @@ export default class EndPointsURL{
         this.orden_seguimiento_update_estado = `${domain}/${produccion_res}/orden_seguimiento/{id}/update_estado`;
         this.orden_produccion_update_estado = `${domain}/${produccion_res}/orden_produccion/{id}/update_estado`;
         this.search_ordenes_by_responsable = `${domain}/${produccion_res}/ordenes_produccion/responsable/{responsableId}`;
+
+        // recursos de produccion endpoints
+        this.save_recurso_produccion = `${domain}/${recursos_produccion_res}`;
 
         // movimientos endpoints
         this.search_products_with_stock = `${domain}/${movimientos_res}/search_products_with_stock`;

--- a/src/pages/Productos/CrearRecursoProduccion.tsx
+++ b/src/pages/Productos/CrearRecursoProduccion.tsx
@@ -1,0 +1,94 @@
+import {useState} from 'react';
+import {Box, Button, FormControl, FormLabel, Heading, Input, VStack, useToast} from '@chakra-ui/react';
+import axios from 'axios';
+
+import EndPointsURL from '../../api/EndPointsURL';
+import {input_style} from '../../styles/styles_general';
+import {RecursoProduccion} from './types';
+
+function CrearRecursoProduccion() {
+    const [nombre, setNombre] = useState('');
+    const [capacidadTotal, setCapacidadTotal] = useState('');
+    const [cantidadDisponible, setCantidadDisponible] = useState('');
+    const [capacidadPorHora, setCapacidadPorHora] = useState('');
+    const [turnos, setTurnos] = useState('');
+    const [horasPorTurno, setHorasPorTurno] = useState('');
+
+    const toast = useToast();
+    const endPoints = new EndPointsURL();
+
+    const clearFields = () => {
+        setNombre('');
+        setCapacidadTotal('');
+        setCantidadDisponible('');
+        setCapacidadPorHora('');
+        setTurnos('');
+        setHorasPorTurno('');
+    };
+
+    const handleSubmit = async () => {
+        const recurso: RecursoProduccion = {
+            nombre,
+            capacidadTotal: capacidadTotal ? parseFloat(capacidadTotal) : undefined,
+            cantidadDisponible: cantidadDisponible ? parseInt(cantidadDisponible) : undefined,
+            capacidadPorHora: capacidadPorHora ? parseFloat(capacidadPorHora) : undefined,
+            turnos: turnos ? parseInt(turnos) : undefined,
+            horasPorTurno: horasPorTurno ? parseFloat(horasPorTurno) : undefined,
+        };
+        try {
+            await axios.post(endPoints.save_recurso_produccion, recurso);
+            toast({
+                title: 'Recurso creado',
+                status: 'success',
+                duration: 3000,
+                isClosable: true,
+            });
+            clearFields();
+        } catch (e) {
+            toast({
+                title: 'Error al crear recurso',
+                description: (e as Error).message,
+                status: 'error',
+                duration: 3000,
+                isClosable: true,
+            });
+        }
+    };
+
+    return (
+        <Box p={4}>
+            <Heading size="md" mb={4}>Crear Recurso de Producción</Heading>
+            <VStack spacing={4} align="stretch">
+                <FormControl isRequired>
+                    <FormLabel>Nombre</FormLabel>
+                    <Input value={nombre} onChange={(e) => setNombre(e.target.value)} sx={input_style} />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Capacidad Total</FormLabel>
+                    <Input type="number" value={capacidadTotal} onChange={(e) => setCapacidadTotal(e.target.value)} sx={input_style} />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Cantidad Disponible</FormLabel>
+                    <Input type="number" value={cantidadDisponible} onChange={(e) => setCantidadDisponible(e.target.value)} sx={input_style} />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Capacidad por Hora</FormLabel>
+                    <Input type="number" value={capacidadPorHora} onChange={(e) => setCapacidadPorHora(e.target.value)} sx={input_style} />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Turnos</FormLabel>
+                    <Input type="number" value={turnos} onChange={(e) => setTurnos(e.target.value)} sx={input_style} />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Horas por Turno</FormLabel>
+                    <Input type="number" value={horasPorTurno} onChange={(e) => setHorasPorTurno(e.target.value)} sx={input_style} />
+                </FormControl>
+                <Button colorScheme="teal" onClick={handleSubmit}>Guardar</Button>
+                <Button colorScheme="orange" onClick={clearFields}>Limpiar</Button>
+            </VStack>
+        </Box>
+    );
+}
+
+export default CrearRecursoProduccion;
+

--- a/src/pages/Productos/DefinicionProcesosTabs.tsx
+++ b/src/pages/Productos/DefinicionProcesosTabs.tsx
@@ -1,6 +1,7 @@
 import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/react';
 import {FaArrowLeft} from 'react-icons/fa';
 import DefinicionProcesosTab from './DefinicionProcesosTab';
+import CrearRecursoProduccion from './CrearRecursoProduccion';
 import {my_style_tab} from '../../styles/styles_general.tsx';
 
 interface Props {
@@ -16,10 +17,14 @@ export function DefinicionProcesosTabs({onBack}: Props) {
             <Tabs isFitted gap="1em" variant="line">
                 <TabList>
                     <Tab sx={my_style_tab}>Definición de Procesos</Tab>
+                    <Tab sx={my_style_tab}>Recursos Producción</Tab>
                 </TabList>
                 <TabPanels>
                     <TabPanel>
                         <DefinicionProcesosTab />
+                    </TabPanel>
+                    <TabPanel>
+                        <CrearRecursoProduccion />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -97,3 +97,13 @@ export interface Familia{
      familiaNombre: string;
      familiaDescripcion: string;
 }
+
+export interface RecursoProduccion {
+    id?: number;
+    nombre: string;
+    capacidadTotal?: number;
+    cantidadDisponible?: number;
+    capacidadPorHora?: number;
+    turnos?: number;
+    horasPorTurno?: number;
+}


### PR DESCRIPTION
## Summary
- add CrearRecursoProduccion component with form and axios call
- wire new Recursos Producción tab into DefinicionProcesosTabs
- expose save_recurso_produccion endpoint and types

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-storybook')*


------
https://chatgpt.com/codex/tasks/task_e_688f9ef7bdac83329429c233723c1d17