### PR TITLE
chore: sanitize gruposActivos before send

### DIFF
--- a/src/pages/ActivosFijos/Incorporacion/step_three/StepThreeValSend.tsx
+++ b/src/pages/ActivosFijos/Incorporacion/step_three/StepThreeValSend.tsx
@@ -40,7 +40,9 @@ export function StepThreeValSend({
         try {
             const formData = new FormData();
 
-            const { documentoSoporte, ...dto } = incorporacionActivoDto;
+            const { documentoSoporte, gruposActivos = [], ...rest } = incorporacionActivoDto;
+            const gruposSinId = gruposActivos.map(({ id, ...g }) => g);
+            const dto = { ...rest, gruposActivos: gruposSinId };
             formData.append(
                 "incorporacionDto",
                 new Blob([JSON.stringify(dto)], { type: "application/json" })


### PR DESCRIPTION
## Summary
- strip `id` from `gruposActivos` before forming incorporation payload

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688fab1245d88332b3d6f4d0af4bb861