### PR TITLE
fix: omit computed OCA field

### DIFF
--- a/src/pages/ActivosFijos/Incorporacion/step_three/StepThreeValSend.tsx
+++ b/src/pages/ActivosFijos/Incorporacion/step_three/StepThreeValSend.tsx
@@ -41,7 +41,7 @@ export function StepThreeValSend({
             const formData = new FormData();
 
             const { documentoSoporte, gruposActivos = [], ...rest } = incorporacionActivoDto;
-            const gruposSinId = gruposActivos.map(({ id, ...g }) => g);
+            const gruposSinId = gruposActivos.map(({ id: _id, ...g }) => g);
             const dto = { ...rest, gruposActivos: gruposSinId };
             formData.append(
                 "incorporacionDto",
@@ -49,9 +49,12 @@ export function StepThreeValSend({
             );
 
             if (incorporacionActivoDto.tipoIncorporacion === TIPO_INCORPORACION.CON_OC && ordenCompraActivo) {
+                const { itemsOrdenCompra = [], ...ordenRest } = ordenCompraActivo;
+                const itemsLimpios = itemsOrdenCompra.map(({ precioUnitarioFinal: _precioUnitarioFinal, ...item }) => item);
+                const ordenLimpia = { ...ordenRest, itemsOrdenCompra: itemsLimpios };
                 formData.append(
                     "ordenCompraActivo",
-                    new Blob([JSON.stringify(ordenCompraActivo)], { type: "application/json" })
+                    new Blob([JSON.stringify(ordenLimpia)], { type: "application/json" })
                 );
             }
 


### PR DESCRIPTION
## Summary
- strip non-persisted `precioUnitarioFinal` from OCA payload

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-storybook"; installed plugin, then errors remain)*
- `npm run build` *(fails: TypeScript errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_688faed89ea08332b2a021a726976707