### PR TITLE
feat: gestión de activos fijos para recursos de producción

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -49,6 +49,9 @@ export default class EndPointsURL{
 
     // recursos de produccion
     public save_recurso_produccion:string;
+    public search_recurso_produccion:string;
+    public update_recurso_produccion:string;
+    public activos_fijos_disponibles_rp:string;
 
 
     // compras resource
@@ -101,6 +104,8 @@ export default class EndPointsURL{
     public get_items_by_orden_compra_activo_id: string;
     public update_orden_compra_activo: string;
     public incorporar_activos_fijos: string;
+    public get_activo_fijo: string;
+    public update_activo_fijo: string;
 
     // just in case of need
     // contabilidad resource
@@ -188,6 +193,9 @@ export default class EndPointsURL{
 
         // recursos de produccion endpoints
         this.save_recurso_produccion = `${domain}/${recursos_produccion_res}`;
+        this.search_recurso_produccion = `${domain}/${recursos_produccion_res}/search`;
+        this.update_recurso_produccion = `${domain}/${recursos_produccion_res}/update`;
+        this.activos_fijos_disponibles_rp = `${domain}/${recursos_produccion_res}/activos-fijos-disponibles`;
 
         // movimientos endpoints
         this.search_products_with_stock = `${domain}/${movimientos_res}/search_products_with_stock`;
@@ -228,6 +236,8 @@ export default class EndPointsURL{
         this.get_items_by_orden_compra_activo_id = `${domain}/${activos_fijos_res}/ocaf/{ordenCompraActivoId}/items`;
         this.update_orden_compra_activo = `${domain}/${activos_fijos_res}/ocaf/{ordenCompraActivoId}/update`;
         this.incorporar_activos_fijos = `${domain}/${activos_fijos_res}/incorporar`;
+        this.get_activo_fijo = `${domain}/${activos_fijos_res}/{id}`;
+        this.update_activo_fijo = `${domain}/${activos_fijos_res}/{id}`;
 
         // notifications endpoint
         this.module_notifications = `${domain}/notificaciones/notifications4user`;

--- a/src/pages/ActivosFijos/types.tsx
+++ b/src/pages/ActivosFijos/types.tsx
@@ -46,6 +46,11 @@ export interface ActivoFijo {
     // Campos para ubicación y responsable
     ubicacion?: string;
     responsable?: string;
+    /**
+     * Recurso de producción al que está asignado el activo.
+     * En la mayoría de los casos solo se requiere el identificador.
+     */
+    tipoRecurso?: { id?: number; nombre?: string };
 
     fechaCodificacion?: Date | string;
     fechaBaja?: Date | string;

--- a/src/pages/Productos/AFpickerRP.tsx
+++ b/src/pages/Productos/AFpickerRP.tsx
@@ -1,0 +1,113 @@
+import {Box, Button, Flex, Input, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Table, Tbody, Td, Th, Thead, Tr} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import {ActivoFijo} from '../ActivosFijos/types';
+import MyPagination from '../../components/MyPagination';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (activos: ActivoFijo[]) => void;
+  alreadySelected: ActivoFijo[];
+}
+
+export default function AFpickerRP({isOpen, onClose, onConfirm, alreadySelected}: Props){
+  const endpoints = new EndPointsURL();
+  const [searchText, setSearchText] = useState('');
+  const [available, setAvailable] = useState<ActivoFijo[]>([]);
+  const [selected, setSelected] = useState<ActivoFijo[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const pageSize = 10;
+
+  const fetchAvailable = async (pageNumber:number) => {
+    const dto = {nombreBusqueda: searchText, page: pageNumber, size: pageSize};
+    try{
+      const res = await axios.post(endpoints.activos_fijos_disponibles_rp, dto);
+      let list:ActivoFijo[] = res.data.content || [];
+      const ids = new Set([...alreadySelected, ...selected].map(a=>a.id));
+      list = list.filter(a=>!ids.has(a.id));
+      setAvailable(list);
+      setTotalPages(res.data.totalPages);
+      setPage(pageNumber);
+    }catch(e){
+      setAvailable([]);
+      setTotalPages(1);
+    }
+  };
+
+  useEffect(()=>{ if(isOpen) fetchAvailable(0); }, [isOpen]);
+
+  const handleAdd = (af:ActivoFijo) => {
+    setSelected([...selected, af]);
+    setAvailable(available.filter(a=>a.id!==af.id));
+  };
+
+  const handleRemove = (af:ActivoFijo) => {
+    const newSel = selected.filter(a=>a.id!==af.id);
+    setSelected(newSel);
+    fetchAvailable(page);
+  };
+
+  const handleAccept = () => {
+    onConfirm(selected);
+    setSelected([]);
+    setAvailable([]);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="6xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Seleccionar Activos Fijos</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Flex gap={4}>
+            <Box flex={1}>
+              <Flex mb={2} gap={2}>
+                <Input placeholder='Buscar' value={searchText} onChange={(e)=>setSearchText(e.target.value)} />
+                <Button onClick={()=>fetchAvailable(0)}>Buscar</Button>
+              </Flex>
+              <Table size='sm'>
+                <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                <Tbody>
+                  {available.map(af=> (
+                    <Tr key={af.id}>
+                      <Td>{af.id}</Td>
+                      <Td>{af.nombre}</Td>
+                      <Td><Button size='xs' onClick={()=>handleAdd(af)}>+</Button></Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+              {totalPages>1 && (
+                <MyPagination page={page} totalPages={totalPages} loading={false} handlePageChange={fetchAvailable} />
+              )}
+            </Box>
+            <Box flex={1}>
+              <Table size='sm'>
+                <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                <Tbody>
+                  {selected.map(af=> (
+                    <Tr key={af.id}>
+                      <Td>{af.id}</Td>
+                      <Td>{af.nombre}</Td>
+                      <Td><Button size='xs' colorScheme='red' onClick={()=>handleRemove(af)}>-</Button></Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </Box>
+          </Flex>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>Cancelar</Button>
+          <Button colorScheme='teal' onClick={handleAccept}>Aceptar</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+

--- a/src/pages/Productos/ConsultaRecursosProduccion.tsx
+++ b/src/pages/Productos/ConsultaRecursosProduccion.tsx
@@ -1,0 +1,100 @@
+import {useState} from 'react';
+import {Box, Button, Flex, FormControl, FormLabel, Input, Select, Table, Tbody, Td, Th, Thead, Tr, useToast} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import MyPagination from '../../components/MyPagination';
+import DetalleModRecProd from './DetalleModRecProd';
+import {RecursoProduccion} from './types';
+
+enum TipoBusqueda{ ID='POR_ID', NOMBRE='POR_NOMBRE' }
+
+export default function ConsultaRecursosProduccion(){
+  const [estado, setEstado] = useState(0);
+  const [recursoSel, setRecursoSel] = useState<RecursoProduccion>();
+  const [refreshFn, setRefreshFn] = useState<()=>void>(()=>()=>{});
+
+  if(estado===1 && recursoSel){
+    return <DetalleModRecProd recurso={recursoSel} setEstado={setEstado} refreshSearch={refreshFn} />;
+  }
+
+  return <PanelBusqueda setEstado={setEstado} setRecursoSel={setRecursoSel} setRefreshFn={setRefreshFn}/>;
+}
+
+type PanelProps = {
+  setEstado: (n:number)=>void;
+  setRecursoSel: (r:RecursoProduccion)=>void;
+  setRefreshFn: (fn:()=>void)=>void;
+};
+
+function PanelBusqueda({setEstado,setRecursoSel,setRefreshFn}:PanelProps){
+  const [searchType, setSearchType] = useState<TipoBusqueda>(TipoBusqueda.ID);
+  const [searchText, setSearchText] = useState('');
+  const [recursos, setRecursos] = useState<RecursoProduccion[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const pageSize = 10;
+  const toast = useToast();
+  const endpoints = new EndPointsURL();
+
+  const fetchRecursos = async (pageNumber:number) => {
+    setPage(pageNumber);
+    const dto = {tipoBusqueda: searchType, valorBusqueda: searchText, page: pageNumber, size: pageSize};
+    try{
+      const res = await axios.post(endpoints.search_recurso_produccion, dto);
+      setRecursos(res.data.content);
+      setTotalPages(res.data.totalPages);
+    }catch(e){
+      toast({title:'Error al buscar', status:'error', duration:3000, isClosable:true});
+      setRecursos([]);
+      setTotalPages(1);
+    }
+  };
+
+  const handleSearch = () => fetchRecursos(0);
+
+  const verDetalles = (r:RecursoProduccion) => {
+    setRecursoSel(r);
+    setRefreshFn(()=>()=>fetchRecursos(page));
+    setEstado(1);
+  };
+
+  return (
+    <Flex direction="column" p={4} gap={4}>
+      <Box p={4} borderWidth="1px" borderRadius="lg">
+        <Flex gap={4} alignItems="end">
+          <FormControl flex={2}>
+            <FormLabel>{searchType===TipoBusqueda.ID? 'ID' : 'Nombre'}</FormLabel>
+            <Input value={searchText} onChange={e=>setSearchText(e.target.value)} />
+          </FormControl>
+          <FormControl flex={1}>
+            <FormLabel>Tipo de Búsqueda</FormLabel>
+            <Select value={searchType} onChange={e=>setSearchType(e.target.value as TipoBusqueda)}>
+              <option value={TipoBusqueda.ID}>ID</option>
+              <option value={TipoBusqueda.NOMBRE}>Nombre</option>
+            </Select>
+          </FormControl>
+          <Button colorScheme='blue' onClick={handleSearch}>Buscar</Button>
+        </Flex>
+      </Box>
+      <Box>
+        <Table size='sm'>
+          <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th>Descripción</Th><Th></Th></Tr></Thead>
+          <Tbody>
+            {recursos.map(r=>(
+              <Tr key={r.id}>
+                <Td>{r.id}</Td>
+                <Td>{r.nombre}</Td>
+                <Td>{r.descripcion}</Td>
+                <Td><Button size='xs' onClick={()=>verDetalles(r)}>Ver Detalles</Button></Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Box>
+      {totalPages>1 && (
+        <MyPagination page={page} totalPages={totalPages} loading={false} handlePageChange={fetchRecursos} />
+      )}
+    </Flex>
+  );
+}
+

--- a/src/pages/Productos/DefinicionProcesosTabs.tsx
+++ b/src/pages/Productos/DefinicionProcesosTabs.tsx
@@ -2,6 +2,7 @@ import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/
 import {FaArrowLeft} from 'react-icons/fa';
 import DefinicionProcesosTab from './DefinicionProcesosTab';
 import CrearRecursoProduccion from './CrearRecursoProduccion';
+import ConsultaRecursosProduccion from './ConsultaRecursosProduccion';
 import {my_style_tab} from '../../styles/styles_general.tsx';
 
 interface Props {
@@ -17,7 +18,8 @@ export function DefinicionProcesosTabs({onBack}: Props) {
             <Tabs isFitted gap="1em" variant="line">
                 <TabList>
                     <Tab sx={my_style_tab}>Definición de Procesos</Tab>
-                    <Tab sx={my_style_tab}>Recursos Producción</Tab>
+                    <Tab sx={my_style_tab}>Crear Recurso Producción</Tab>
+                    <Tab sx={my_style_tab}>Consulta Recursos Producción</Tab>
                 </TabList>
                 <TabPanels>
                     <TabPanel>
@@ -25,6 +27,9 @@ export function DefinicionProcesosTabs({onBack}: Props) {
                     </TabPanel>
                     <TabPanel>
                         <CrearRecursoProduccion />
+                    </TabPanel>
+                    <TabPanel>
+                        <ConsultaRecursosProduccion />
                     </TabPanel>
                 </TabPanels>
             </Tabs>

--- a/src/pages/Productos/DetalleModRecProd.tsx
+++ b/src/pages/Productos/DetalleModRecProd.tsx
@@ -1,0 +1,68 @@
+import {Box, Button, Flex, FormControl, FormLabel, Heading, Input, useToast} from '@chakra-ui/react';
+import {useState} from 'react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import {RecursoProduccion} from './types';
+import RPAFmanager from './RPAFmanager';
+import {ActivoFijo} from '../ActivosFijos/types';
+
+interface Props {
+  recurso: RecursoProduccion;
+  setEstado: (estado:number)=>void;
+  refreshSearch?: ()=>void;
+}
+
+export default function DetalleModRecProd({recurso, setEstado, refreshSearch}:Props){
+  const [editMode, setEditMode] = useState(false);
+  const [recursoData, setRecursoData] = useState<RecursoProduccion>({...recurso});
+  const toast = useToast();
+  const endpoints = new EndPointsURL();
+
+  const handleSave = async () => {
+    const dto = {oldRecursoProduccion: recurso, newRecursoProduccion: recursoData};
+    try{
+      await axios.put(endpoints.update_recurso_produccion, dto);
+      setEditMode(false);
+      toast({title:'Recurso actualizado',status:'success',duration:3000,isClosable:true});
+      if(refreshSearch) refreshSearch();
+    }catch(e){
+      toast({title:'Error al actualizar recurso',status:'error',duration:3000,isClosable:true});
+    }
+  };
+
+  const handleActivosChange = (afs: ActivoFijo[]) => {
+    setRecursoData({...recursoData, activosFijos: afs});
+  };
+
+  const handleBack = () => {
+    setEstado(0);
+    if(refreshSearch) refreshSearch();
+  };
+
+  return (
+    <Box p={4}>
+      <Button mb={4} onClick={handleBack}>Volver</Button>
+      <Heading size='md' mb={4}>Detalle Recurso Producción</Heading>
+      <FormControl mb={4} isRequired>
+        <FormLabel>Nombre</FormLabel>
+        <Input value={recursoData.nombre} onChange={e=>setRecursoData({...recursoData, nombre:e.target.value})} isDisabled={!editMode} />
+      </FormControl>
+      <FormControl mb={4} isRequired>
+        <FormLabel>Descripción</FormLabel>
+        <Input value={recursoData.descripcion} onChange={e=>setRecursoData({...recursoData, descripcion:e.target.value})} isDisabled={!editMode} />
+      </FormControl>
+      <RPAFmanager recursoId={recursoData.id} activos={recursoData.activosFijos || []} onChange={handleActivosChange} />
+      <Flex mt={4} gap={2}>
+        {editMode ? (
+          <>
+            <Button colorScheme='teal' onClick={handleSave}>Guardar</Button>
+            <Button onClick={()=>{setEditMode(false); setRecursoData({...recurso});}}>Cancelar</Button>
+          </>
+        ) : (
+          <Button onClick={()=>setEditMode(true)}>Editar</Button>
+        )}
+      </Flex>
+    </Box>
+  );
+}
+

--- a/src/pages/Productos/RPAFmanager.tsx
+++ b/src/pages/Productos/RPAFmanager.tsx
@@ -1,0 +1,90 @@
+import {Box, Button, Flex, Table, Tbody, Td, Th, Thead, Tr, useToast} from '@chakra-ui/react';
+import {useState} from 'react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import {ActivoFijo} from '../ActivosFijos/types';
+import AFpickerRP from './AFpickerRP';
+
+interface Props {
+  recursoId?: number;
+  activos: ActivoFijo[];
+  onChange: (activos: ActivoFijo[]) => void;
+}
+
+export default function RPAFmanager({recursoId, activos, onChange}: Props){
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const toast = useToast();
+  const endpoints = new EndPointsURL();
+
+  const unassignActivo = async (af: ActivoFijo) => {
+    if(!recursoId) return;
+    try{
+      const getUrl = endpoints.get_activo_fijo.replace('{id}', af.id);
+      const updUrl = endpoints.update_activo_fijo.replace('{id}', af.id);
+      const res = await axios.get(getUrl);
+      const full = res.data;
+      full.tipoRecurso = null;
+      await axios.put(updUrl, full);
+    }catch(e){
+      toast({title:'Error al desasignar activo', status:'error'});
+    }
+  };
+
+  const handleRemove = async (af: ActivoFijo) => {
+    if(recursoId){
+      await unassignActivo(af);
+    }
+    onChange(activos.filter(a => a.id !== af.id));
+  };
+
+  const assignActivos = async (lista: ActivoFijo[]) => {
+    if(recursoId){
+      for(const af of lista){
+        try{
+          const getUrl = endpoints.get_activo_fijo.replace('{id}', af.id);
+          const updUrl = endpoints.update_activo_fijo.replace('{id}', af.id);
+          const res = await axios.get(getUrl);
+          const full = res.data;
+          full.tipoRecurso = {id: recursoId};
+          await axios.put(updUrl, full);
+        }catch(e){
+          toast({title:'Error al asignar activo', status:'error'});
+        }
+      }
+    }
+    onChange([...activos, ...lista]);
+  };
+
+  return (
+    <Box>
+      <Flex justify="space-between" mb={2}>
+        <Button colorScheme='teal' size='sm' onClick={()=>setIsPickerOpen(true)}>Agregar Activo Fijo</Button>
+      </Flex>
+      <Table size='sm'>
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Nombre</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {activos.map(af=> (
+            <Tr key={af.id}>
+              <Td>{af.id}</Td>
+              <Td>{af.nombre}</Td>
+              <Td><Button size='xs' colorScheme='red' onClick={()=>handleRemove(af)}>Remover</Button></Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <AFpickerRP
+        isOpen={isPickerOpen}
+        onClose={()=>setIsPickerOpen(false)}
+        onConfirm={(sel)=>{assignActivos(sel); setIsPickerOpen(false);}}
+        alreadySelected={activos}
+      />
+    </Box>
+  );
+}
+

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -4,6 +4,8 @@ export const UNIDADES = {L:"L", KG:"KG", U:"U"};
 export const TIPOS_MATERIALES = {materiaPrima: 1, materialDeEmpaque: 2};
 export const IVA_VALUES = {'iva_0':0, 'iva_5':5,'iva_19':19, };
 
+import type {ActivoFijo} from '../ActivosFijos/types';
+
 /**
  * interfaces para la codificacion de materias primas
  */
@@ -101,9 +103,11 @@ export interface Familia{
 export interface RecursoProduccion {
     id?: number;
     nombre: string;
+    descripcion: string;
     capacidadTotal?: number;
     cantidadDisponible?: number;
     capacidadPorHora?: number;
     turnos?: number;
     horasPorTurno?: number;
+    activosFijos?: ActivoFijo[];
 }


### PR DESCRIPTION
## Summary
- add endpoints and types to support managing activos fijos in recursos de producción
- create RPAFmanager and AFpickerRP to assign or quitar activos
- enable consulta y edición de recursos de producción con nuevos componentes
- remove redundant RecursoProduccionDetalle wrapper; use DetalleModRecProd directly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: TS errors in TransaccionesAlmacen and Usuarios modules)


------
https://chatgpt.com/codex/tasks/task_e_688fbb8d57c0833290478539379fe3c7