### PR TITLE
feat: add proceso produccion creation

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -53,6 +53,11 @@ export default class EndPointsURL{
     public update_recurso_produccion:string;
     public activos_fijos_disponibles_rp:string;
 
+    // procesos de produccion
+    public save_proceso_produccion:string;
+    public get_procesos_produccion_pag:string;
+    public update_proceso_produccion:string;
+
 
     // compras resource
     public byProveedorAndDate:string;
@@ -140,6 +145,7 @@ export default class EndPointsURL{
         const auth_res = 'api/auth';
         const personal_res = 'integrantes-personal';
         const recursos_produccion_res = 'api/recursos-produccion';
+        const procesos_produccion_res = 'api/procesos-produccion';
 
         // productos endpoints
         this.search_mprima = `${domain}/${productos_res}/search_mprima`;
@@ -196,6 +202,11 @@ export default class EndPointsURL{
         this.search_recurso_produccion = `${domain}/${recursos_produccion_res}/search`;
         this.update_recurso_produccion = `${domain}/${recursos_produccion_res}/update`;
         this.activos_fijos_disponibles_rp = `${domain}/${recursos_produccion_res}/activos-fijos-disponibles`;
+
+        // procesos de produccion endpoints
+        this.save_proceso_produccion = `${domain}/${procesos_produccion_res}`;
+        this.get_procesos_produccion_pag = `${domain}/${procesos_produccion_res}/paginados`;
+        this.update_proceso_produccion = `${domain}/${procesos_produccion_res}/{id}`;
 
         // movimientos endpoints
         this.search_products_with_stock = `${domain}/${movimientos_res}/search_products_with_stock`;

--- a/src/pages/Productos/DefinicionProcesosTab.tsx
+++ b/src/pages/Productos/DefinicionProcesosTab.tsx
@@ -1,18 +1,142 @@
-
-import { 
-  Box, 
+import {useEffect, useState} from 'react';
+import {
+  Box,
   Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  VStack,
+  Button,
+  CheckboxGroup,
+  Checkbox,
+  Stack,
+  useToast,
 } from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import {input_style} from '../../styles/styles_general';
+import {RecursoProduccion, ProcesoProduccionEntity} from './types';
 
 function DefinicionProcesosTab() {
+  const [nombre, setNombre] = useState('');
+  const [setUpTime, setSetUpTime] = useState<number>(0);
+  const [processTime, setProcessTime] = useState<number>(0);
+  const [recursos, setRecursos] = useState<RecursoProduccion[]>([]);
+  const [recursosSel, setRecursosSel] = useState<string[]>([]);
+
+  const toast = useToast();
+  const endPoints = new EndPointsURL();
+
+  useEffect(() => {
+    const fetchRecursos = async () => {
+      try {
+        const dto = {
+          tipoBusqueda: 'POR_NOMBRE',
+          valorBusqueda: '',
+          page: 0,
+          size: 100,
+        };
+        const res = await axios.post(endPoints.search_recurso_produccion, dto);
+        setRecursos(res.data.content);
+      } catch (e) {
+        toast({
+          title: 'Error al cargar recursos',
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    };
+    fetchRecursos();
+  }, []);
+
+  const clearFields = () => {
+    setNombre('');
+    setSetUpTime(0);
+    setProcessTime(0);
+    setRecursosSel([]);
+  };
+
+  const handleSubmit = async () => {
+    const proceso: ProcesoProduccionEntity = {
+      nombre,
+      recursosRequeridos: recursosSel.map((id) => ({id: Number(id)})) as RecursoProduccion[],
+      setUpTime,
+      processTime,
+    };
+    try {
+      await axios.post(endPoints.save_proceso_produccion, proceso);
+      toast({
+        title: 'Proceso creado',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      clearFields();
+    } catch (e) {
+      toast({
+        title: 'Error al crear proceso',
+        description: (e as Error).message,
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
 
   return (
     <Box p={4}>
-      <Heading size="md" mb={4}>Definición de Procesos</Heading>
-
-
+      <Heading size="md" mb={4}>
+        Crear Proceso de Producción
+      </Heading>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Nombre</FormLabel>
+          <Input value={nombre} onChange={(e) => setNombre(e.target.value)} sx={input_style} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Set-up Time (min)</FormLabel>
+          <Input
+            type="number"
+            value={setUpTime}
+            onChange={(e) => setSetUpTime(Number(e.target.value))}
+            sx={input_style}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Process Time (min)</FormLabel>
+          <Input
+            type="number"
+            value={processTime}
+            onChange={(e) => setProcessTime(Number(e.target.value))}
+            sx={input_style}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Recursos Requeridos</FormLabel>
+          <CheckboxGroup
+            value={recursosSel}
+            onChange={(vals) => setRecursosSel(vals as string[])}
+          >
+            <Stack spacing={2}>
+              {recursos.map((r) => (
+                <Checkbox key={r.id} value={String(r.id)}>
+                  {r.nombre}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        </FormControl>
+        <Button colorScheme="teal" onClick={handleSubmit}>
+          Guardar
+        </Button>
+        <Button colorScheme="orange" onClick={clearFields}>
+          Limpiar
+        </Button>
+      </VStack>
     </Box>
   );
 }
 
 export default DefinicionProcesosTab;
+

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -111,3 +111,11 @@ export interface RecursoProduccion {
     horasPorTurno?: number;
     activosFijos?: ActivoFijo[];
 }
+
+export interface ProcesoProduccionEntity {
+    procesoId?: number;
+    nombre: string;
+    recursosRequeridos: RecursoProduccion[];
+    setUpTime: number;
+    processTime: number;
+}


### PR DESCRIPTION
## Summary
- allow defining production processes from the Productos page
- wire up new backend endpoints for procesos de producción

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: The file should have a default export ... etc.)

------
https://chatgpt.com/codex/tasks/task_e_68911b341a248332b76ce71adfcc54bd