### PR TITLE
feat: add resource picker for process creation

### DIFF
--- a/src/pages/Productos/DefinicionProcesosTab.tsx
+++ b/src/pages/Productos/DefinicionProcesosTab.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {
   Box,
   Heading,
@@ -7,48 +7,22 @@ import {
   Input,
   VStack,
   Button,
-  CheckboxGroup,
-  Checkbox,
-  Stack,
   useToast,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import EndPointsURL from '../../api/EndPointsURL';
 import {input_style} from '../../styles/styles_general';
 import {RecursoProduccion, ProcesoProduccionEntity} from './types';
+import PPRPmanager from './PPRPmanager';
 
 function DefinicionProcesosTab() {
   const [nombre, setNombre] = useState('');
   const [setUpTime, setSetUpTime] = useState<number>(0);
   const [processTime, setProcessTime] = useState<number>(0);
-  const [recursos, setRecursos] = useState<RecursoProduccion[]>([]);
-  const [recursosSel, setRecursosSel] = useState<string[]>([]);
+  const [recursosSel, setRecursosSel] = useState<RecursoProduccion[]>([]);
 
   const toast = useToast();
   const endPoints = new EndPointsURL();
-
-  useEffect(() => {
-    const fetchRecursos = async () => {
-      try {
-        const dto = {
-          tipoBusqueda: 'POR_NOMBRE',
-          valorBusqueda: '',
-          page: 0,
-          size: 100,
-        };
-        const res = await axios.post(endPoints.search_recurso_produccion, dto);
-        setRecursos(res.data.content);
-      } catch (e) {
-        toast({
-          title: 'Error al cargar recursos',
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-        });
-      }
-    };
-    fetchRecursos();
-  }, []);
 
   const clearFields = () => {
     setNombre('');
@@ -60,7 +34,7 @@ function DefinicionProcesosTab() {
   const handleSubmit = async () => {
     const proceso: ProcesoProduccionEntity = {
       nombre,
-      recursosRequeridos: recursosSel.map((id) => ({id: Number(id)})) as RecursoProduccion[],
+      recursosRequeridos: recursosSel.map((r) => ({id: r.id})) as RecursoProduccion[],
       setUpTime,
       processTime,
     };
@@ -114,18 +88,7 @@ function DefinicionProcesosTab() {
         </FormControl>
         <FormControl>
           <FormLabel>Recursos Requeridos</FormLabel>
-          <CheckboxGroup
-            value={recursosSel}
-            onChange={(vals) => setRecursosSel(vals as string[])}
-          >
-            <Stack spacing={2}>
-              {recursos.map((r) => (
-                <Checkbox key={r.id} value={String(r.id)}>
-                  {r.nombre}
-                </Checkbox>
-              ))}
-            </Stack>
-          </CheckboxGroup>
+          <PPRPmanager recursos={recursosSel} onChange={setRecursosSel} />
         </FormControl>
         <Button colorScheme="teal" onClick={handleSubmit}>
           Guardar

--- a/src/pages/Productos/PPRPmanager.tsx
+++ b/src/pages/Productos/PPRPmanager.tsx
@@ -1,0 +1,55 @@
+import {Box, Button, Flex, Table, Tbody, Td, Th, Thead, Tr} from '@chakra-ui/react';
+import {useState} from 'react';
+import {RecursoProduccion} from './types';
+import RecursoProduccionPicker from './RecursoProduccionPicker';
+
+interface Props {
+  recursos: RecursoProduccion[];
+  onChange: (recursos: RecursoProduccion[]) => void;
+  editMode?: boolean;
+}
+
+export default function PPRPmanager({recursos, onChange, editMode = true}: Props){
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  const handleRemove = (r: RecursoProduccion) => {
+    onChange(recursos.filter(a => a.id !== r.id));
+  };
+
+  const assignRecursos = (lista: RecursoProduccion[]) => {
+    onChange([...recursos, ...lista]);
+  };
+
+  return (
+    <Box>
+      <Flex justify="space-between" mb={2}>
+        <Button colorScheme='teal' size='sm' onClick={()=>setIsPickerOpen(true)} isDisabled={!editMode}>Agregar Recurso</Button>
+      </Flex>
+      <Table size='sm'>
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Nombre</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {recursos.map(r=> (
+            <Tr key={r.id}>
+              <Td>{r.id}</Td>
+              <Td>{r.nombre}</Td>
+              <Td><Button size='xs' colorScheme='red' onClick={()=>handleRemove(r)} isDisabled={!editMode}>Remover</Button></Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <RecursoProduccionPicker
+        isOpen={isPickerOpen}
+        onClose={()=>setIsPickerOpen(false)}
+        onConfirm={(sel)=>{assignRecursos(sel); setIsPickerOpen(false);}}
+        alreadySelected={recursos}
+      />
+    </Box>
+  );
+}
+

--- a/src/pages/Productos/RecursoProduccionPicker.tsx
+++ b/src/pages/Productos/RecursoProduccionPicker.tsx
@@ -1,0 +1,123 @@
+import {Box, Button, Flex, Input, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Table, Tbody, Td, Th, Thead, Tr} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL';
+import {RecursoProduccion} from './types';
+import MyPagination from '../../components/MyPagination';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (recursos: RecursoProduccion[]) => void;
+  alreadySelected: RecursoProduccion[];
+}
+
+export default function RecursoProduccionPicker({isOpen, onClose, onConfirm, alreadySelected}: Props){
+  const endpoints = new EndPointsURL();
+  const [searchText, setSearchText] = useState('');
+  const [available, setAvailable] = useState<RecursoProduccion[]>([]);
+  const [selected, setSelected] = useState<RecursoProduccion[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const pageSize = 10;
+
+  const fetchAvailable = async (pageNumber:number) => {
+    setLoading(true);
+    const dto = {tipoBusqueda: 'POR_NOMBRE', valorBusqueda: searchText, page: pageNumber, size: pageSize};
+    try{
+      const res = await axios.post(endpoints.search_recurso_produccion, dto);
+      let list:RecursoProduccion[] = res.data.content || [];
+      const ids = new Set([...alreadySelected, ...selected].map(r=>r.id));
+      list = list.filter(r=>!ids.has(r.id));
+      setAvailable(list);
+      setTotalPages(res.data.totalPages);
+      setPage(pageNumber);
+    }catch(e){
+      setAvailable([]);
+      setTotalPages(1);
+    }finally{
+      setLoading(false);
+    }
+  };
+
+  useEffect(()=>{ if(isOpen) fetchAvailable(0); }, [isOpen]);
+
+  const handleAdd = (r:RecursoProduccion) => {
+    setSelected([...selected, r]);
+    setAvailable(available.filter(a=>a.id!==r.id));
+  };
+
+  const handleRemove = (r:RecursoProduccion) => {
+    const newSel = selected.filter(a=>a.id!==r.id);
+    setSelected(newSel);
+    fetchAvailable(page);
+  };
+
+  const handleAccept = () => {
+    onConfirm(selected);
+    setSelected([]);
+    setAvailable([]);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="6xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Seleccionar Recursos de Producción</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Flex gap={4}>
+            <Box flex={1}>
+              <Flex mb={2} gap={2}>
+                <Input placeholder='Buscar' value={searchText} onChange={(e)=>setSearchText(e.target.value)} />
+                <Button
+                  onClick={()=>fetchAvailable(0)}
+                  isLoading={loading}
+                  loadingText="Buscando..."
+                >
+                  Buscar
+                </Button>
+              </Flex>
+              <Table size='sm'>
+                <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                <Tbody>
+                  {available.map(r=> (
+                    <Tr key={r.id}>
+                      <Td>{r.id}</Td>
+                      <Td>{r.nombre}</Td>
+                      <Td><Button size='xs' onClick={()=>handleAdd(r)}>+</Button></Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+              {totalPages>1 && (
+                <MyPagination page={page} totalPages={totalPages} loading={loading} handlePageChange={fetchAvailable} />
+              )}
+            </Box>
+            <Box flex={1}>
+              <Table size='sm'>
+                <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                <Tbody>
+                  {selected.map(r=> (
+                    <Tr key={r.id}>
+                      <Td>{r.id}</Td>
+                      <Td>{r.nombre}</Td>
+                      <Td><Button size='xs' colorScheme='red' onClick={()=>handleRemove(r)}>-</Button></Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </Box>
+          </Flex>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose}>Cancelar</Button>
+          <Button colorScheme='teal' onClick={handleAccept}>Aceptar</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace checkboxes with PPRPmanager to manage production resources for processes
- add RecursoProduccionPicker dialog for searching and selecting resources

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint plugin "eslint-plugin-storybook" missing)
- `npm run build` (fails: TypeScript errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_6895404ea0e483328c3dee9060a8f2c1