### PR TITLE
feat: add proceso production picker

### DIFF
--- a/src/pages/Productos/CreadorProcesos/components/ProcesoProduccionPicker.tsx
+++ b/src/pages/Productos/CreadorProcesos/components/ProcesoProduccionPicker.tsx
@@ -1,12 +1,90 @@
-import {useState} from 'react';
-import {Flex} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import {Flex, Select, useToast} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../../../api/EndPointsURL';
+import {ProcesoProduccionEntity} from '../../types';
+import MyPagination from '../../../../components/MyPagination';
 
-type Props = {};
+interface Props {
+    onSelect?: (proceso: ProcesoProduccionEntity | null) => void;
+}
 
-export function ProcesoProduccionPicker(props: Props) {
+export function ProcesoProduccionPicker({onSelect}: Props) {
+    const endPoints = new EndPointsURL();
+    const toast = useToast();
+
+    const [procesos, setProcesos] = useState<ProcesoProduccionEntity[]>([]);
+    const [selectedId, setSelectedId] = useState<number | ''>('');
+    const [page, setPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(1);
+    const [loading, setLoading] = useState(false);
+    const pageSize = 10;
+
+    const fetchProcesos = async (pageNumber: number) => {
+        setLoading(true);
+        try {
+            const res = await axios.get(endPoints.get_procesos_produccion_pag, {
+                params: {page: pageNumber, size: pageSize},
+            });
+            setProcesos(res.data.content || []);
+            setTotalPages(res.data.totalPages || 1);
+            setPage(pageNumber);
+        } catch (e) {
+            toast({
+                title: 'Error',
+                description: 'No se pudieron obtener los procesos.',
+                status: 'error',
+                duration: 5000,
+                isClosable: true,
+            });
+            setProcesos([]);
+            setTotalPages(1);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchProcesos(0);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const id = e.target.value;
+        const numericId = id === '' ? '' : Number(id);
+        setSelectedId(numericId);
+        const proceso = procesos.find(p => p.procesoId === Number(id)) || null;
+        onSelect?.(proceso);
+    };
+
+    const handlePageChange = (newPage: number) => {
+        if (newPage >= 0 && newPage < totalPages) {
+            fetchProcesos(newPage);
+        }
+    };
+
     return (
-        <Flex>
-
+        <Flex direction="column" w="full">
+            <Select
+                placeholder={loading ? 'Cargando...' : 'Seleccione un proceso'}
+                value={selectedId}
+                onChange={handleChange}
+                isDisabled={loading}
+            >
+                {procesos.map(p => (
+                    <option key={p.procesoId} value={p.procesoId}>
+                        {p.nombre}
+                    </option>
+                ))}
+            </Select>
+            {totalPages > 1 && (
+                <MyPagination
+                    page={page}
+                    totalPages={totalPages}
+                    loading={loading}
+                    handlePageChange={handlePageChange}
+                />
+            )}
         </Flex>
     );
 }


### PR DESCRIPTION
## Summary
- add ProcesoProduccionPicker to fetch and select production processes

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 131 problems in existing files)


------
https://chatgpt.com/codex/tasks/task_e_689678bbb24883328646bedcb74dc458