### PR TITLE
feat: add warehouse transaction search to payments

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -129,6 +129,7 @@ export default class EndPointsURL{
     // public get_balance_comprobacion: string;
     // public get_balance_general: string;
     // public get_estado_resultados: string;
+    public search_transacciones_almacen: string;
 
     public domain: string;
 
@@ -232,6 +233,7 @@ export default class EndPointsURL{
         this.get_cuentas = `${domain}/${contabilidad_res}/cuentas`;
         this.get_libro_mayor = `${domain}/${contabilidad_res}/libro-mayor`;
         this.get_periodos = `${domain}/${contabilidad_res}/periodos`;
+        this.search_transacciones_almacen = `${domain}/${contabilidad_res}/transacciones`;
 
         // organigrama endpoints
         const organigrama_res = 'organigrama';

--- a/src/pages/PagosProveedores/BuscarTranOcmAsentar.tsx
+++ b/src/pages/PagosProveedores/BuscarTranOcmAsentar.tsx
@@ -1,0 +1,136 @@
+import {useState} from 'react';
+import {
+  Flex,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Spinner,
+  useToast
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../api/EndPointsURL.tsx';
+import MyPagination from '../../components/MyPagination.tsx';
+import {
+  EstadoContable,
+  TransaccionAlmacen,
+  DTO_SearchTransaccionAlmacen,
+  PaginatedResponse
+} from './types.tsx';
+
+const endPoints = new EndPointsURL();
+
+export default function BuscarTranOcmAsentar() {
+  const [estadoContable, setEstadoContable] = useState<EstadoContable>(EstadoContable.PENDIENTE);
+  const [fechaInicio, setFechaInicio] = useState('');
+  const [fechaFin, setFechaFin] = useState('');
+  const [transacciones, setTransacciones] = useState<TransaccionAlmacen[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+  const pageSize = 10;
+
+  const handleSearch = async (pageNumber = 0) => {
+    setLoading(true);
+    setPage(pageNumber);
+    try {
+      const dto: DTO_SearchTransaccionAlmacen = {
+        estadoContable,
+        fechaInicio: fechaInicio ? `${fechaInicio}T00:00:00` : undefined,
+        fechaFin: fechaFin ? `${fechaFin}T23:59:59` : undefined,
+        page: pageNumber,
+        size: pageSize,
+      };
+      const resp = await axios.post<PaginatedResponse<TransaccionAlmacen>>(endPoints.search_transacciones_almacen, dto);
+      setTransacciones(resp.data.content);
+      setTotalPages(resp.data.totalPages);
+    } catch (e) {
+      toast({
+        title: 'Error al buscar transacciones',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+      setTransacciones([]);
+      setTotalPages(0);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Flex direction="column" w="full" gap={4}>
+      <Flex wrap="wrap" gap={4}>
+        <FormControl w={["100%","200px"]}>
+          <FormLabel>Estado contable</FormLabel>
+          <Select value={estadoContable} onChange={e => setEstadoContable(e.target.value as EstadoContable)}>
+            <option value={EstadoContable.PENDIENTE}>Pendiente</option>
+            <option value={EstadoContable.CONTABILIZADA}>Contabilizada</option>
+            <option value={EstadoContable.NO_APLICA}>No aplica</option>
+          </Select>
+        </FormControl>
+        <FormControl w={["100%","200px"]}>
+          <FormLabel>Fecha inicio</FormLabel>
+          <Input type="date" value={fechaInicio} onChange={e => setFechaInicio(e.target.value)} />
+        </FormControl>
+        <FormControl w={["100%","200px"]}>
+          <FormLabel>Fecha fin</FormLabel>
+          <Input type="date" value={fechaFin} onChange={e => setFechaFin(e.target.value)} />
+        </FormControl>
+        <Flex alignItems="flex-end">
+          <Button colorScheme="blue" onClick={() => handleSearch(0)} isLoading={loading}>
+            Buscar
+          </Button>
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" w="full">
+        <Table variant="simple" size="sm">
+          <Thead>
+            <Tr>
+              <Th>ID</Th>
+              <Th>Fecha</Th>
+              <Th>Estado</Th>
+              <Th>Entidad</Th>
+              <Th>ID Entidad</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {loading && (
+              <Tr>
+                <Td colSpan={5} textAlign="center">
+                  <Spinner />
+                </Td>
+              </Tr>
+            )}
+            {!loading && transacciones.length === 0 && (
+              <Tr>
+                <Td colSpan={5} textAlign="center">
+                  No hay resultados
+                </Td>
+              </Tr>
+            )}
+            {transacciones.map(tran => (
+              <Tr key={tran.transaccionId}>
+                <Td>{tran.transaccionId}</Td>
+                <Td>{new Date(tran.fechaTransaccion).toLocaleString()}</Td>
+                <Td>{tran.estadoContable}</Td>
+                <Td>{tran.tipoEntidadCausante}</Td>
+                <Td>{tran.idEntidadCausante}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+        <MyPagination page={page} totalPages={totalPages} loading={loading} handlePageChange={handleSearch} />
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/pages/PagosProveedores/PagosProveedoresPage.tsx
+++ b/src/pages/PagosProveedores/PagosProveedoresPage.tsx
@@ -1,6 +1,7 @@
 import {Container, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from "@chakra-ui/react";
 import MyHeader from "../../components/MyHeader.tsx";
 import {my_style_tab} from "../../styles/styles_general.tsx";
+import BuscarTranOcmAsentar from "./BuscarTranOcmAsentar.tsx";
 
 export default function PagosProveedoresPage() {
     return (
@@ -16,15 +17,12 @@ export default function PagosProveedoresPage() {
                     </TabList>
 
                     <TabPanels>
-
                         <TabPanel>
-                            Lista de transacciones de alamacen sin asentar
+                            <BuscarTranOcmAsentar />
                         </TabPanel>
-
                         <TabPanel>
                             Lista de Facturas Vencidas
                         </TabPanel>
-
                     </TabPanels>
 
                 </Tabs>

--- a/src/pages/PagosProveedores/types.tsx
+++ b/src/pages/PagosProveedores/types.tsx
@@ -38,3 +38,37 @@ export interface FiltrosPago {
   proveedorId?: number;
   metodo?: MetodoPago;
 }
+
+// ===============================
+// Transacciones de almacén para contabilización
+// ===============================
+
+export enum EstadoContable {
+  PENDIENTE = 'PENDIENTE',
+  CONTABILIZADA = 'CONTABILIZADA',
+  NO_APLICA = 'NO_APLICA',
+}
+
+export interface TransaccionAlmacen {
+  transaccionId: number;
+  fechaTransaccion: string;
+  estadoContable: EstadoContable;
+  tipoEntidadCausante: string;
+  idEntidadCausante: number;
+}
+
+export interface DTO_SearchTransaccionAlmacen {
+  estadoContable?: EstadoContable;
+  fechaInicio?: string;
+  fechaFin?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface PaginatedResponse<T> {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  number: number;
+  size: number;
+}


### PR DESCRIPTION
## Summary
- integrate contabilidad transacciones endpoint in EndPointsURL
- add types and component to search warehouse transactions pending to settle
- display search component in PagosProveedores page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 130 problems)


------
https://chatgpt.com/codex/tasks/task_e_68995465522083328c86122202da3db2