### PR TITLE
feat(productos): add inventareable field

### DIFF
--- a/src/pages/Productos/Basic/CodificarMaterialesTab.tsx
+++ b/src/pages/Productos/Basic/CodificarMaterialesTab.tsx
@@ -12,7 +12,8 @@ import {
     Select,
     Flex,
     HStack,
-    IconButton
+    IconButton,
+    Switch
 } from '@chakra-ui/react';
 import axios, { AxiosError } from 'axios';
 
@@ -31,6 +32,7 @@ function CodificarMaterialesTab() {
     const [codigo, setCodigo] = useState('');
     const [url_ftecnica, setUrl_ftecnica] = useState('');
     const [tipoMaterial, setTipoMaterial] = useState(TIPOS_MATERIALES.materiaPrima);
+    const [inventareable, setInventareable] = useState(false);
 
     const [ivaPercentage, setIvaPercentage] = useState(0);
 
@@ -49,6 +51,7 @@ function CodificarMaterialesTab() {
         setIvaPercentage(0);
         setTipoMaterial(TIPOS_MATERIALES.materiaPrima);
         setTipo_unidad(UNIDADES.KG);
+        setInventareable(false);
     };
 
     // Validate data: all fields must be non-empty, codigo numeric, cantidad positive, and a PDF file must be loaded.
@@ -171,6 +174,7 @@ function CodificarMaterialesTab() {
             cantidadUnidad: cantidad_unidad,
             tipo_producto: TIPOS_PRODUCTOS.materiaPrima,
             tipoMaterial: tipoMaterial,
+            inventareable,
             ivaPercentual: ivaPercentage
         };
 
@@ -327,6 +331,13 @@ function CodificarMaterialesTab() {
                                 </Select>
                             </FormControl>
                         </Flex>
+                    </GridItem>
+
+                    <GridItem colSpan={1}>
+                        <FormControl display="flex" alignItems="center">
+                            <FormLabel mb="0">Inventareable</FormLabel>
+                            <Switch isChecked={inventareable} onChange={(e) => setInventareable(e.target.checked)} />
+                        </FormControl>
                     </GridItem>
 
                     <GridItem colSpan={3}>

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -21,6 +21,7 @@ export interface Producto{
     nombre: string;
     observaciones?: string;
     costo: number;
+    inventareable?: boolean;
     tipoUnidades: string;
     cantidadUnidad: string;
     fechaCreacion?: string;


### PR DESCRIPTION
## Summary
- allow materials to specify optional `inventareable` flag in product types
- expose `inventareable` toggle on material creation form and include it in submit payload

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689de13aa9408332b5e9cc307f9e02b2