### PR TITLE
Refactor families to categories in product module

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -22,9 +22,9 @@ export default class EndPointsURL{
     // notifications endpoint
     public module_notifications: string;
 
-    // familias endpoints
-    public get_familias: string;
-    public save_familia: string;
+    // categorias endpoints
+    public get_categorias: string;
+    public save_categoria: string;
 
 
     // Proveedores resouce
@@ -166,9 +166,9 @@ export default class EndPointsURL{
         this.carga_masiva_mprims = `${domain}/${productos_res}/bulk_upload_excel`;
         this.consulta_productos = `${domain}/${productos_res}/consulta1`;
 
-        // Familias endpoints
-        this.get_familias = `${domain}/familias`;
-        this.save_familia = `${domain}/familias`;
+        // Categorias endpoints
+        this.get_categorias = `${domain}/categorias`;
+        this.save_categoria = `${domain}/categorias`;
 
         // Proveedores endpoints
         this.save_proveedores = `${domain}/${proveedores_res}/save`;

--- a/src/pages/Productos/DefSemiTer/CategoriasTab.tsx
+++ b/src/pages/Productos/DefSemiTer/CategoriasTab.tsx
@@ -24,39 +24,39 @@ import {
     Text
 } from '@chakra-ui/react';
 
-import {Familia} from '../types.tsx';
+import {Categoria} from '../types.tsx';
 
-export function FamiliasTab() {
-    const [familias, setFamilias] = useState<Familia[]>([]);
+export function CategoriasTab() {
+    const [categorias, setCategorias] = useState<Categoria[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
 
     const [formData, setFormData] = useState({
-        familiaId: '',
-        familiaNombre: '',
-        familiaDescripcion: ''
+        categoriaId: '',
+        categoriaNombre: '',
+        categoriaDescripcion: ''
     });
 
     const [submitting, setSubmitting] = useState<boolean>(false);
     const toast = useToast();
     const endPoints = new EndPointsURL();
 
-    const fetchFamilias = async () => {
+    const fetchCategorias = async () => {
         try {
             setLoading(true);
             setError(null);
-            const response = await axios.get(endPoints.get_familias);
-            setFamilias(response.data);
+            const response = await axios.get(endPoints.get_categorias);
+            setCategorias(response.data);
         } catch (error) {
-            console.error('Error fetching familias:', error);
-            setError('Error al cargar las familias. Por favor, intente nuevamente.');
+            console.error('Error fetching categorias:', error);
+            setError('Error al cargar las categorías. Por favor, intente nuevamente.');
         } finally {
             setLoading(false);
         }
     };
 
     useEffect(() => {
-        fetchFamilias();
+        fetchCategorias();
     }, []);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -70,29 +70,29 @@ export function FamiliasTab() {
     const handleSubmit = async () => {
         try {
             setSubmitting(true);
-            const newFamilia = {
-                familiaId: Number(formData.familiaId),
-                familiaNombre: formData.familiaNombre,
-                familiaDescripcion: formData.familiaDescripcion
+            const newCategoria = {
+                categoriaId: Number(formData.categoriaId),
+                categoriaNombre: formData.categoriaNombre,
+                categoriaDescripcion: formData.categoriaDescripcion
             };
 
-            await axios.post(endPoints.save_familia, newFamilia);
+            await axios.post(endPoints.save_categoria, newCategoria);
 
             toast({
-                title: 'Familia creada',
-                description: 'La familia ha sido creada exitosamente',
+                title: 'Categoría creada',
+                description: 'La categoría ha sido creada exitosamente',
                 status: 'success',
                 duration: 3000,
                 isClosable: true,
             });
 
             handleClear();
-            fetchFamilias(); // Recargar la lista después de crear
+            fetchCategorias(); // Recargar la lista después de crear
         } catch (error) {
-            console.error('Error creating familia:', error);
+            console.error('Error creating categoria:', error);
 
             // Manejo mejorado de excepciones
-            let errorMessage = 'No se pudo crear la familia. Por favor, intente nuevamente.';
+            let errorMessage = 'No se pudo crear la categoría. Por favor, intente nuevamente.';
 
             // Extraer el mensaje de error específico del backend
             if (axios.isAxiosError(error) && error.response) {
@@ -118,27 +118,27 @@ export function FamiliasTab() {
 
     const handleClear = () => {
         setFormData({
-            familiaId: '',
-            familiaNombre: '',
-            familiaDescripcion: ''
+            categoriaId: '',
+            categoriaNombre: '',
+            categoriaDescripcion: ''
         });
     };
 
-    const isFormValid = formData.familiaNombre.trim() !== '' && formData.familiaDescripcion.trim() !== '';
+    const isFormValid = formData.categoriaNombre.trim() !== '' && formData.categoriaDescripcion.trim() !== '';
 
     return (
         <Grid templateColumns="1fr 1fr" gap={6} p={4}>
             <Box p={6} borderWidth="1px" borderRadius="lg">
                 <VStack spacing={4} align="stretch">
-                    <Heading size="md" mb={4}>Nueva Familia</Heading>
+                    <Heading size="md" mb={4}>Nueva Categoría</Heading>
 
                     <FormControl isRequired>
-                        <FormLabel>Familia ID</FormLabel>
+                        <FormLabel>Categoría ID</FormLabel>
                         <Input
-                            name="familiaId"
-                            value={formData.familiaId}
+                            name="categoriaId"
+                            value={formData.categoriaId}
                             onChange={handleInputChange}
-                            placeholder="Id de la familia"
+                            placeholder="Id de la categoría"
                             isDisabled={submitting}
                         />
                     </FormControl>
@@ -146,10 +146,10 @@ export function FamiliasTab() {
                     <FormControl isRequired>
                         <FormLabel>Nombre</FormLabel>
                         <Input
-                            name="familiaNombre"
-                            value={formData.familiaNombre}
+                            name="categoriaNombre"
+                            value={formData.categoriaNombre}
                             onChange={handleInputChange}
-                            placeholder="Nombre de la familia"
+                            placeholder="Nombre de la categoría"
                             isDisabled={submitting}
                         />
                     </FormControl>
@@ -157,10 +157,10 @@ export function FamiliasTab() {
                     <FormControl isRequired>
                         <FormLabel>Descripción</FormLabel>
                         <Input
-                            name="familiaDescripcion"
-                            value={formData.familiaDescripcion}
+                            name="categoriaDescripcion"
+                            value={formData.categoriaDescripcion}
                             onChange={handleInputChange}
-                            placeholder="Descripción de la familia"
+                            placeholder="Descripción de la categoría"
                             isDisabled={submitting}
                         />
                     </FormControl>
@@ -179,7 +179,7 @@ export function FamiliasTab() {
                 </VStack>
             </Box>
             <Box p={6} borderWidth="1px" borderRadius="lg">
-                <Heading size="md" mb={4}>Familias Existentes</Heading>
+                <Heading size="md" mb={4}>Categorías Existentes</Heading>
 
                 {loading && <Spinner size="md" />}
 
@@ -190,14 +190,14 @@ export function FamiliasTab() {
                     </Alert>
                 )}
 
-                {!loading && !error && familias.length === 0 && (
+                {!loading && !error && categorias.length === 0 && (
                     <Alert status="info" mb={4}>
                         <AlertIcon />
-                        <Text>No hay familias registradas. Cree una nueva familia utilizando el formulario.</Text>
+                        <Text>No hay categorías registradas. Cree una nueva categoría utilizando el formulario.</Text>
                     </Alert>
                 )}
 
-                {!loading && !error && familias.length > 0 && (
+                {!loading && !error && categorias.length > 0 && (
                     <Table variant="simple">
                         <Thead>
                             <Tr>
@@ -207,11 +207,11 @@ export function FamiliasTab() {
                             </Tr>
                         </Thead>
                         <Tbody>
-                            {familias.map((familia) => (
-                                <Tr key={familia.familiaId}>
-                                    <Td>{familia.familiaId}</Td>
-                                    <Td>{familia.familiaNombre}</Td>
-                                    <Td>{familia.familiaDescripcion}</Td>
+                            {categorias.map((categoria) => (
+                                <Tr key={categoria.categoriaId}>
+                                    <Td>{categoria.categoriaId}</Td>
+                                    <Td>{categoria.categoriaNombre}</Td>
+                                    <Td>{categoria.categoriaDescripcion}</Td>
                                 </Tr>
                             ))}
                         </Tbody>

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/CodificarSemioTermiTab.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/CodificarSemioTermiTab.tsx
@@ -42,13 +42,13 @@ export default function CodificarSemioTermiTab({ isActive = false }: CodificarSe
     const [semioter2, setSemioter2] = useState<ProductoSemiter>();
     const [semioter3, setSemioter3] = useState<ProductoSemiter>();
 
-    // Estado para controlar la actualización de familias
-    const [refreshFamilias, setRefreshFamilias] = useState(0);
+    // Estado para controlar la actualización de categorías
+    const [refreshCategorias, setRefreshCategorias] = useState(0);
 
-    // Efecto para actualizar familias cuando la pestaña se activa
+    // Efecto para actualizar categorías cuando la pestaña se activa
     useEffect(() => {
         if (isActive) {
-            setRefreshFamilias(prev => prev + 1);
+            setRefreshCategorias(prev => prev + 1);
         }
     }, [isActive]);
 
@@ -59,7 +59,7 @@ export default function CodificarSemioTermiTab({ isActive = false }: CodificarSe
                 <StepOne 
                     setActiveStep={setActiveStep} 
                     setSemioter={setSemioter} 
-                    refreshFamilias={refreshFamilias}
+                    refreshCategorias={refreshCategorias}
                 />
             );
         }

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepOne/StepOne.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepOne/StepOne.tsx
@@ -7,16 +7,16 @@ import {
 import {useState, useEffect} from "react";
 import axios from 'axios';
 import EndPointsURL from '../../../../../api/EndPointsURL.tsx';
-import {ProductoSemiter, UNIDADES, TIPOS_PRODUCTOS, Familia} from "../../../types.tsx";
+import {ProductoSemiter, UNIDADES, TIPOS_PRODUCTOS, Categoria} from "../../../types.tsx";
 
 
 interface props {
     setActiveStep: (step: number) => void;
     setSemioter: (semioter: ProductoSemiter) => void;
-    refreshFamilias?: number;
+    refreshCategorias?: number;
 }
 
-export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0}: props) {
+export default function StepOne({setActiveStep, setSemioter, refreshCategorias = 0}: props) {
     // Local copy of the order's items to track verification state.
 
     const [productoId, setProductoId] = useState<string>("");
@@ -26,39 +26,39 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
     const [observaciones, setObservaciones] = useState<string>("");
     const [tipo_producto, setTipo_producto] = useState<string>(TIPOS_PRODUCTOS.terminado);
 
-    // Estados para manejar familias
-    const [familiasDisponibles, setFamiliasDisponibles] = useState<Familia[]>([]);
-    const [selectedFamiliaId, setSelectedFamiliaId] = useState<number | null>(null);
-    const [loadingFamilias, setLoadingFamilias] = useState<boolean>(false);
-    const [errorFamilias, setErrorFamilias] = useState<string | null>(null);
+    // Estados para manejar categorías
+    const [categoriasDisponibles, setCategoriasDisponibles] = useState<Categoria[]>([]);
+    const [selectedCategoriaId, setSelectedCategoriaId] = useState<number | null>(null);
+    const [loadingCategorias, setLoadingCategorias] = useState<boolean>(false);
+    const [errorCategorias, setErrorCategorias] = useState<string | null>(null);
 
     const endPoints = new EndPointsURL();
     const toast = useToast();
 
-    // Función para cargar las familias
-    const fetchFamilias = async () => {
+    // Función para cargar las categorías
+    const fetchCategorias = async () => {
         if (tipo_producto === TIPOS_PRODUCTOS.terminado) {
             try {
-                setLoadingFamilias(true);
-                setErrorFamilias(null);
-                const response = await axios.get(endPoints.get_familias);
-                setFamiliasDisponibles(response.data);
+                setLoadingCategorias(true);
+                setErrorCategorias(null);
+                const response = await axios.get(endPoints.get_categorias);
+                setCategoriasDisponibles(response.data);
 
-                // Si no hay familias, mostrar un mensaje
+                // Si no hay categorías, mostrar un mensaje
                 if (response.data.length === 0) {
                     toast({
                         title: "Advertencia",
-                        description: "No hay familias disponibles. Por favor, cree una familia primero.",
+                        description: "No hay categorías disponibles. Por favor, cree una categoría primero.",
                         status: "warning",
                         duration: 5000,
                         isClosable: true,
                     });
                 }
             } catch (error) {
-                console.error('Error fetching familias:', error);
+                console.error('Error fetching categorias:', error);
 
                 // Manejo mejorado de excepciones
-                let errorMessage = 'Error al cargar las familias';
+                let errorMessage = 'Error al cargar las categorías';
 
                 // Extraer el mensaje de error específico del backend
                 if (axios.isAxiosError(error) && error.response) {
@@ -69,7 +69,7 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
                     }
                 }
 
-                setErrorFamilias(errorMessage);
+                setErrorCategorias(errorMessage);
                 toast({
                     title: "Error",
                     description: errorMessage,
@@ -78,21 +78,21 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
                     isClosable: true,
                 });
             } finally {
-                setLoadingFamilias(false);
+                setLoadingCategorias(false);
             }
         }
     };
 
-    // Cargar familias cuando el componente se monta, cuando cambia el tipo de producto,
-    // o cuando se actualiza refreshFamilias
+    // Cargar categorías cuando el componente se monta, cuando cambia el tipo de producto,
+    // o cuando se actualiza refreshCategorias
     useEffect(() => {
-        fetchFamilias();
-    }, [tipo_producto, refreshFamilias]);
+        fetchCategorias();
+    }, [tipo_producto, refreshCategorias]);
 
-    // Limpiar la selección de familia cuando se cambia a producto semiterminado
+    // Limpiar la selección de categoría cuando se cambia a producto semiterminado
     useEffect(() => {
         if (tipo_producto !== TIPOS_PRODUCTOS.terminado) {
-            setSelectedFamiliaId(null);
+            setSelectedCategoriaId(null);
         }
     }, [tipo_producto]);
 
@@ -101,7 +101,7 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
         setNombre("");
         setCantidadUnidad("");
         setObservaciones("");
-        setSelectedFamiliaId(null);
+        setSelectedCategoriaId(null);
     }
 
     const ValidarDatos = (): boolean => {
@@ -174,11 +174,11 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
         }
         */
 
-        // Validar que se haya seleccionado una familia para productos terminados
-        if (tipo_producto === TIPOS_PRODUCTOS.terminado && !selectedFamiliaId) {
+        // Validar que se haya seleccionado una categoría para productos terminados
+        if (tipo_producto === TIPOS_PRODUCTOS.terminado && !selectedCategoriaId) {
             toast({
                 title: "Validación",
-                description: "Debe seleccionar una familia para productos terminados.",
+                description: "Debe seleccionar una categoría para productos terminados.",
                 status: "warning",
                 duration: 3000,
                 isClosable: true,
@@ -191,8 +191,8 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
 
     const onClickSiguiente = () => {
         if(ValidarDatos()){
-            // Encontrar la familia seleccionada
-            const selectedFamilia = familiasDisponibles.find(f => f.familiaId === selectedFamiliaId);
+            // Encontrar la categoría seleccionada
+            const selectedCategoria = categoriasDisponibles.find(f => f.categoriaId === selectedCategoriaId);
 
             const semioter: ProductoSemiter = {
                 productoId: productoId!,
@@ -201,7 +201,7 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
                 tipoUnidades: tipoUnidades,
                 cantidadUnidad: cantidadUnidad!,
                 tipo_producto: tipo_producto,
-                familia: tipo_producto === TIPOS_PRODUCTOS.terminado ? selectedFamilia : undefined
+                categoria: tipo_producto === TIPOS_PRODUCTOS.terminado ? selectedCategoria : undefined
             };
             setSemioter(semioter);
             setActiveStep(1);
@@ -274,28 +274,28 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
 
                 <GridItem colSpan={1} display={tipo_producto === TIPOS_PRODUCTOS.terminado ? "flex" : "none"}>
                     <FormControl isRequired={tipo_producto === TIPOS_PRODUCTOS.terminado}>
-                        <FormLabel>Familia</FormLabel>
+                        <FormLabel>Categoría</FormLabel>
                         <Select
-                            value={selectedFamiliaId || ""}
-                            onChange={(e) => setSelectedFamiliaId(Number(e.target.value))}
-                            isDisabled={loadingFamilias || familiasDisponibles.length === 0}
-                            placeholder="Seleccione una familia"
+                            value={selectedCategoriaId || ""}
+                            onChange={(e) => setSelectedCategoriaId(Number(e.target.value))}
+                            isDisabled={loadingCategorias || categoriasDisponibles.length === 0}
+                            placeholder="Seleccione una categoría"
                         >
-                            {familiasDisponibles.map((familia) => (
-                                <option key={familia.familiaId} value={familia.familiaId}>
-                                    {familia.familiaNombre}
+                            {categoriasDisponibles.map((categoria) => (
+                                <option key={categoria.categoriaId} value={categoria.categoriaId}>
+                                    {categoria.categoriaNombre}
                                 </option>
                             ))}
                         </Select>
-                        {loadingFamilias && <Spinner size="sm" ml={2} />}
-                        {errorFamilias && (
+                        {loadingCategorias && <Spinner size="sm" ml={2} />}
+                        {errorCategorias && (
                             <Text color="red.500" fontSize="sm" mt={1}>
-                                {errorFamilias}
+                                {errorCategorias}
                             </Text>
                         )}
-                        {!loadingFamilias && !errorFamilias && familiasDisponibles.length === 0 && (
+                        {!loadingCategorias && !errorCategorias && categoriasDisponibles.length === 0 && (
                             <Text color="orange.500" fontSize="sm" mt={1}>
-                                No hay familias disponibles. Por favor, cree una familia primero.
+                                No hay categorías disponibles. Por favor, cree una categoría primero.
                             </Text>
                         )}
                     </FormControl>
@@ -329,8 +329,8 @@ export default function StepOne({setActiveStep, setSemioter, refreshFamilias = 0
                     colorScheme={"teal"}
                     onClick={onClickSiguiente}
                     isDisabled={
-                        tipo_producto === TIPOS_PRODUCTOS.terminado && 
-                        (familiasDisponibles.length === 0 || !selectedFamiliaId)
+                        tipo_producto === TIPOS_PRODUCTOS.terminado &&
+                        (categoriasDisponibles.length === 0 || !selectedCategoriaId)
                     }
                 >
                     Siguiente

--- a/src/pages/Productos/DefSemiTer/TerminadosSemiterminadosTabs.tsx
+++ b/src/pages/Productos/DefSemiTer/TerminadosSemiterminadosTabs.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import {Button, Flex, Tab, TabList, TabPanel, TabPanels, Tabs} from '@chakra-ui/react';
 import {FaArrowLeft} from 'react-icons/fa';
 import CodificarSemioTermiTab from './CodificarSemioTermiTab/CodificarSemioTermiTab.tsx';
-import {FamiliasTab} from './FamiliasTab.tsx';
+import {CategoriasTab} from './CategoriasTab.tsx';
 import InformeProductosTab from '../Basic/InformeProductosTab.tsx';
 import {my_style_tab} from '../../../styles/styles_general.tsx';
 
@@ -26,7 +26,7 @@ export function TerminadosSemiterminadosTabs({user, productosAccessLevel, onBack
                         <Tab sx={my_style_tab}>Codificar Terminado/Semiterminado</Tab>
                     )}
                     {(user === 'master' || productosAccessLevel >= 2) && (
-                        <Tab sx={my_style_tab}>Familias</Tab>
+                        <Tab sx={my_style_tab}>Categorías</Tab>
                     )}
                     <Tab sx={my_style_tab}>Consulta</Tab>
                 </TabList>
@@ -39,7 +39,7 @@ export function TerminadosSemiterminadosTabs({user, productosAccessLevel, onBack
                     )}
                     {(user === 'master' || productosAccessLevel >= 2) && (
                         <TabPanel>
-                            <FamiliasTab />
+                            <CategoriasTab />
                         </TabPanel>
                     )}
                     <TabPanel>

--- a/src/pages/Productos/ProductosMenuSelection.tsx
+++ b/src/pages/Productos/ProductosMenuSelection.tsx
@@ -61,7 +61,7 @@ export function ProductosMenuSelection({setViewMode, user, productosAccessLevel}
                     </CardHeader>
                     <CardBody display="flex" flexDirection="column" alignItems="center" justifyContent="center" p={6}>
                         <Icon as={FaBoxOpen} boxSize="5em" mb={4} />
-                        <Text textAlign="center">Gestionar terminados, semiterminados y familias</Text>
+                        <Text textAlign="center">Gestionar terminados, semiterminados y categorías</Text>
                     </CardBody>
                 </Card>
 

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -92,13 +92,13 @@ export interface ProductoSemiter {
     cantidadUnidad: string;
     tipo_producto: string;
     procesoProduccion?: ProcesoProduccion; // se determina a la hora de definir el proceso - step 3
-    familia?: Familia; // solo se usa para terminado, por ello es opcional
+    categoria?: Categoria; // solo se usa para terminado, por ello es opcional
 }
 
-export interface Familia{
-     familiaId: number;
-     familiaNombre: string;
-     familiaDescripcion: string;
+export interface Categoria{
+     categoriaId: number;
+     categoriaNombre: string;
+     categoriaDescripcion: string;
 }
 
 export interface RecursoProduccion {


### PR DESCRIPTION
## Summary
- rename family endpoints to category endpoints
- introduce Categoria interface and update components
- rename FamiliasTab to CategoriasTab and adjust references

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars', 'ban-types', etc.)*
- `npm run build` *(fails: TypeScript compilation errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f814404833281ad029996c36e13