### PR TITLE
Allow decimal quantities for insumos

### DIFF
--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaSeleccion.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaSeleccion.tsx
@@ -123,6 +123,8 @@ const ItemBandejaSeleccion: React.FC<ItemBandejaSeleccionProps> = ({
                         <NumberInput
                             size="sm"
                             min={0}
+                            step={0.1}
+                            precision={2}
                             value={insumo.cantidadRequerida}
                             onChange={(_vStr, vNum) =>
                                 // Nota: el tipo de productoId en props es string, que coincide con la definición en Producto.

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/StepTwo.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/StepTwo.tsx
@@ -28,11 +28,11 @@ const StepTwo: React.FC<Props> = ({ setActiveStep, semioter, setSemioter2 }) => 
         setCosto(totalCost);
     }, [selectedInsumos]);
 
-    // Validate if we can continue: at least 2 insumos and each with cantidadRequerida > 1
+    // Validate if we can continue: at least 2 insumos and each with cantidadRequerida > 0
     const validoContinuar = (): boolean => {
         if (selectedInsumos.length < 2) return false;
         for (const insumo of selectedInsumos) {
-            if (isNaN(insumo.cantidadRequerida) || insumo.cantidadRequerida < 1) {
+            if (isNaN(insumo.cantidadRequerida) || insumo.cantidadRequerida <= 0) {
                 return false;
             }
         }
@@ -89,7 +89,7 @@ const StepTwo: React.FC<Props> = ({ setActiveStep, semioter, setSemioter2 }) => 
             toast({
                 title: "Validación fallida",
                 description:
-                    "Debe seleccionar al menos 2 insumos y cada uno debe tener una cantidad requerida mayor a 1.",
+                    "Debe seleccionar al menos 2 insumos y cada uno debe tener una cantidad requerida mayor a 0.",
                 status: "error",
                 duration: 3000,
                 isClosable: true,


### PR DESCRIPTION
## Summary
- permit decimal quantities by validating `cantidadRequerida > 0`
- allow fractional input in item selection with `NumberInput` step and precision

## Testing
- `node -e "const cloneDeep=require('lodash/cloneDeep'); const selected=[{producto:{productoId:'1',costo:100}, cantidadRequerida:1.5, subtotal:150}]; const costo=selected.reduce((sum,i)=>sum+i.producto.costo*i.cantidadRequerida,0); const semioter={insumos:[],costo:''}; const semioter2=cloneDeep(semioter); semioter2.insumos=cloneDeep(selected); semioter2.costo=String(costo); console.log(JSON.stringify(semioter2, null, 2));"`
- `npm run lint` (fails: ESLint couldn't find the plugin "eslint-plugin-storybook"; after installing plugin, still fails due to unrelated lint errors)
- `npm run build` (fails: TypeScript errors in unrelated files)

------
https://chatgpt.com/codex/tasks/task_e_68a4daaa47808332834867bc84543f79