### PR TITLE
Add production process serialization and confirmation step

### DIFF
--- a/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
+++ b/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
@@ -17,7 +17,7 @@ import "@xyflow/react/dist/style.css";
 import MaterialPrimarioNode from "./Nodos/MaterialPrimarioNode.tsx";
 import ProcesoNode from "./Nodos/ProcesoNode.tsx";
 import { ProcesoNodeData } from "./types.tsx";
-import { ProductoSemiter, ProcesoProduccionEntity } from "../../types.tsx";
+import { ProductoSemiter, ProcesoProduccionEntity, ProcesoProduccionCompleto, ProcesoProduccionNode } from "../../types.tsx";
 import TargetNode from "./Nodos/TargetNode.tsx";
 import EditProcesoNodeDialog from "./EditProcesoNodeDialog.tsx";
 import { Stat, StatLabel, StatNumber } from "@chakra-ui/icons";
@@ -34,10 +34,11 @@ const nodeTypes = {
 interface Props {
     semioter2: ProductoSemiter;
     setSemiter3: (semioter3: ProductoSemiter) => void;
+    rendimientoTeorico: number;
     onValidityChange?: (isValid: boolean) => void;
 }
 
-export default function ProcessDesigner({ semioter2, setSemiter3, onValidityChange }: Props) {
+export default function ProcessDesigner({ semioter2, setSemiter3, rendimientoTeorico, onValidityChange }: Props) {
     // Create nodes for each material (insumo) from ProductoSemiter.
     // Use a fallback empty array if insumos is undefined.
     const getMatPrimasNodes = (semi: ProductoSemiter): Node[] =>
@@ -110,6 +111,20 @@ export default function ProcessDesigner({ semioter2, setSemiter3, onValidityChan
         (params: Connection) => setEdges((eds) => addEdge(params, eds)),
         [setEdges]
     );
+
+    useEffect(() => {
+        const procesos: ProcesoProduccionNode[] = nodes.map((n) => ({
+            id: n.id,
+            data: n.data,
+            type: n.type,
+            targetIds: edges.filter((e) => e.source === n.id).map((e) => e.target),
+        }));
+        const procesoCompleto: ProcesoProduccionCompleto = {
+            procesosProduccion: procesos,
+            rendimientoTeorico,
+        };
+        setSemiter3({ ...semioter2, procesoProduccionCompleto: procesoCompleto });
+    }, [nodes, edges, rendimientoTeorico, semioter2, setSemiter3]);
 
     // Validate connection rules.
     const isValidConnection = useCallback(

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/CodificarSemioTermiTab.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/CodificarSemioTermiTab.tsx
@@ -15,6 +15,7 @@ import {useState, useEffect} from "react";
 import {ProductoSemiter} from "../../types.tsx";
 import StepTwo from "./StepTwo/StepTwo.tsx";
 import StepThree from "./StepThree/StepThree.tsx";
+import StepFour from "./StepFour/StepFour.tsx";
 
 interface CodificarSemioTermiTabProps {
     isActive?: boolean;
@@ -23,10 +24,10 @@ interface CodificarSemioTermiTabProps {
 
 
 const steps = [
-    { title: 'Primero', description: 'Definir Insumos y Otros Campos' },
-    { title: 'Segundo', description: 'Definir Proceso de Produccion' },
-    { title: 'Tercero', description: 'Definir Parametros de Salida' },
-    { title: 'Cuarto', description: 'Finalizacion' },
+    { title: 'Primero', description: 'Definir Producto' },
+    { title: 'Segundo', description: 'Definir Insumos' },
+    { title: 'Tercero', description: 'Definir Proceso de Produccion' },
+    { title: 'Cuarto', description: 'Confirmación' },
 ]
 
 
@@ -68,22 +69,24 @@ export default function CodificarSemioTermiTab({ isActive = false }: CodificarSe
                 <StepTwo setActiveStep={setActiveStep} semioter={semioter!} setSemioter2={setSemioter2}/>
             );
         }
-        if (activeStep === 2) { // subir documento soporte
+        if (activeStep === 2) { // definir proceso de produccion
             return(
                 <StepThree setActiveStep={setActiveStep} semioter2={semioter2!} setSemioter3={setSemioter3}/>
             );
         }
-        if (activeStep === 3) { // verificar los datos y enviar a backend
+        if (activeStep === 3) { // confirmar y guardar
             return(
-                <></>
-            );
-        }
-        if (activeStep === 4){ // ventana de finalizacion, no se hace nada, solo notifica al usuario
-            return(
-                <></>
+                <StepFour setActiveStep={setActiveStep} semioter3={semioter3!} onReset={handleReset} />
             );
         }
     }
+
+    const handleReset = () => {
+        setSemioter(undefined);
+        setSemioter2(undefined);
+        setSemioter3(undefined);
+        setActiveStep(0);
+    };
 
     return(
         <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepFour/StepFour.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepFour/StepFour.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Button, Flex, Box, Heading, useToast } from "@chakra-ui/react";
+import axios from "axios";
+import EndPointsURL from "../../../../../api/EndPointsURL.tsx";
+import { ProductoSemiter } from "../../../types.tsx";
+
+interface Props {
+    setActiveStep: (step: number) => void;
+    semioter3: ProductoSemiter;
+    onReset: () => void;
+}
+
+export default function StepFour({ setActiveStep, semioter3, onReset }: Props) {
+    const toast = useToast();
+    const [loading, setLoading] = useState(false);
+    const endPoints = new EndPointsURL();
+
+    const handleGuardar = async () => {
+        try {
+            setLoading(true);
+            await axios.post(endPoints.save_producto, semioter3);
+            toast({
+                title: "Producto guardado",
+                status: "success",
+                duration: 3000,
+                isClosable: true,
+            });
+            onReset();
+        } catch (e) {
+            toast({
+                title: "Error",
+                description: "No se pudo guardar el producto",
+                status: "error",
+                duration: 3000,
+                isClosable: true,
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleAtras = () => {
+        setActiveStep(2);
+    };
+
+    return (
+        <Flex direction="column" align="center" gap={4} w="full">
+            <Heading size="md">Resumen del Producto</Heading>
+            <Box w="full" bg="gray.50" p={4} borderRadius="md" maxH="300px" overflowY="auto">
+                <pre>{JSON.stringify(semioter3, null, 2)}</pre>
+            </Box>
+            <Flex gap={10}>
+                <Button variant="solid" colorScheme="yellow" onClick={handleAtras} isDisabled={loading}>
+                    Atras
+                </Button>
+                <Button variant="solid" colorScheme="teal" onClick={handleGuardar} isLoading={loading}>
+                    Guardar
+                </Button>
+            </Flex>
+        </Flex>
+    );
+}

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepThree/StepThree.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepThree/StepThree.tsx
@@ -1,6 +1,6 @@
 import { ProductoSemiter } from "../../../types.tsx";
 import ProcessDesigner from "../../../DefProcesses/CreadorProcesos/ProcessDesigner.tsx";
-import { Button, Flex } from "@chakra-ui/react";
+import { Button, Flex, FormControl, FormLabel, NumberInput, NumberInputField } from "@chakra-ui/react";
 import { useState } from "react";
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 export default function StepThree({ setActiveStep, semioter2, setSemioter3 }: Props) {
     // Local state to store whether the process definition is valid.
     const [isProcessValid, setIsProcessValid] = useState(false);
+    const [rendimientoTeorico, setRendimientoTeorico] = useState<number>(0);
 
     const onClickSiguiente = () => {
         setActiveStep(3);
@@ -22,10 +23,22 @@ export default function StepThree({ setActiveStep, semioter2, setSemioter3 }: Pr
     };
 
     return (
-        <Flex direction="column">
+        <Flex direction="column" gap={4}>
+            <FormControl w="sm">
+                <FormLabel>Rendimiento Teórico</FormLabel>
+                <NumberInput
+                    min={0}
+                    value={rendimientoTeorico}
+                    onChange={(_, value) => setRendimientoTeorico(value)}
+                >
+                    <NumberInputField />
+                </NumberInput>
+            </FormControl>
+
             <ProcessDesigner
                 semioter2={semioter2}
                 setSemiter3={setSemioter3}
+                rendimientoTeorico={rendimientoTeorico}
                 onValidityChange={setIsProcessValid}
             />
 
@@ -46,7 +59,7 @@ export default function StepThree({ setActiveStep, semioter2, setSemioter3 }: Pr
                     variant="solid"
                     onClick={onClickSiguiente}
                     flex={2}
-                    isDisabled={!isProcessValid}  // Disabled if process definition is invalid.
+                    isDisabled={!isProcessValid || rendimientoTeorico <= 0}  // Disabled if process definition is invalid.
                 >
                     Siguiente
                 </Button>

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -79,6 +79,18 @@ export interface ProcesoProduccion{
     targetNode: Node;
 }
 
+export interface ProcesoProduccionNode {
+    id: string;
+    data: unknown;
+    type?: string;
+    targetIds: string[];
+}
+
+export interface ProcesoProduccionCompleto {
+    procesosProduccion: ProcesoProduccionNode[];
+    rendimientoTeorico: number;
+}
+
 /**
  * se usa en el tab de codificacion de producto terminado o semiterminado
  */
@@ -91,7 +103,7 @@ export interface ProductoSemiter {
     tipoUnidades: string;
     cantidadUnidad: string;
     tipo_producto: string;
-    procesoProduccion?: ProcesoProduccion; // se determina a la hora de definir el proceso - step 3
+    procesoProduccionCompleto?: ProcesoProduccionCompleto; // se determina a la hora de definir el proceso - step 3
     categoria?: Categoria; // solo se usa para terminado, por ello es opcional
 }
 


### PR DESCRIPTION
## Summary
- Define `ProcesoProduccionCompleto` and replace `procesoProduccion` with `procesoProduccionCompleto` in `ProductoSemiter`
- Capture `rendimientoTeorico` in Step Three and serialize process data to `ProcesoProduccionCompleto`
- Add confirmation step to save product and reset wizard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 96 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e4e6cc9c8332a77124f4e5aa0048