### PR TITLE
refactor process designer callback

### DIFF
--- a/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
+++ b/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
@@ -17,7 +17,7 @@ import "@xyflow/react/dist/style.css";
 import MaterialPrimarioNode from "./Nodos/MaterialPrimarioNode.tsx";
 import ProcesoNode from "./Nodos/ProcesoNode.tsx";
 import { ProcesoNodeData } from "./types.tsx";
-import { ProductoSemiter, ProcesoProduccionEntity, ProcesoProduccionCompleto, ProcesoProduccionNode } from "../../types.tsx";
+import { ProductoSemiter, ProcesoProduccionEntity, ProcesoDiseñado, ProcesoProduccionNode } from "../../types.tsx";
 import TargetNode from "./Nodos/TargetNode.tsx";
 import EditProcesoNodeDialog from "./EditProcesoNodeDialog.tsx";
 import { Stat, StatLabel, StatNumber } from "@chakra-ui/icons";
@@ -33,12 +33,11 @@ const nodeTypes = {
 
 interface Props {
     semioter2: ProductoSemiter;
-    setSemiter3: (semioter3: ProductoSemiter) => void;
-    rendimientoTeorico: number;
+    onProcessChange?: (proceso: ProcesoDiseñado) => void;
     onValidityChange?: (isValid: boolean) => void;
 }
 
-export default function ProcessDesigner({ semioter2, setSemiter3, rendimientoTeorico, onValidityChange }: Props) {
+export default function ProcessDesigner({ semioter2, onProcessChange, onValidityChange }: Props) {
     // Create nodes for each material (insumo) from ProductoSemiter.
     // Use a fallback empty array if insumos is undefined.
     const getMatPrimasNodes = (semi: ProductoSemiter): Node[] =>
@@ -119,12 +118,9 @@ export default function ProcessDesigner({ semioter2, setSemiter3, rendimientoTeo
             type: n.type,
             targetIds: edges.filter((e) => e.source === n.id).map((e) => e.target),
         }));
-        const procesoCompleto: ProcesoProduccionCompleto = {
-            procesosProduccion: procesos,
-            rendimientoTeorico,
-        };
-        setSemiter3({ ...semioter2, procesoProduccionCompleto: procesoCompleto });
-    }, [nodes, edges, rendimientoTeorico, semioter2, setSemiter3]);
+        const proceso: ProcesoDiseñado = { procesosProduccion: procesos };
+        onProcessChange?.(proceso);
+    }, [nodes, edges, onProcessChange]);
 
     // Validate connection rules.
     const isValidConnection = useCallback(

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepThree/StepThree.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepThree/StepThree.tsx
@@ -1,4 +1,4 @@
-import { ProductoSemiter } from "../../../types.tsx";
+import { ProductoSemiter, ProcesoDiseñado, ProcesoProduccionCompleto } from "../../../types.tsx";
 import ProcessDesigner from "../../../DefProcesses/CreadorProcesos/ProcessDesigner.tsx";
 import { Button, Flex, FormControl, FormLabel, NumberInput, NumberInputField } from "@chakra-ui/react";
 import { useState } from "react";
@@ -13,8 +13,14 @@ export default function StepThree({ setActiveStep, semioter2, setSemioter3 }: Pr
     // Local state to store whether the process definition is valid.
     const [isProcessValid, setIsProcessValid] = useState(false);
     const [rendimientoTeorico, setRendimientoTeorico] = useState<number>(0);
+    const [proceso, setProceso] = useState<ProcesoDiseñado>({ procesosProduccion: [] });
 
     const onClickSiguiente = () => {
+        const procesoCompleto: ProcesoProduccionCompleto = {
+            ...proceso,
+            rendimientoTeorico,
+        };
+        setSemioter3({ ...semioter2, procesoProduccionCompleto: procesoCompleto });
         setActiveStep(3);
     };
 
@@ -37,8 +43,7 @@ export default function StepThree({ setActiveStep, semioter2, setSemioter3 }: Pr
 
             <ProcessDesigner
                 semioter2={semioter2}
-                setSemiter3={setSemioter3}
-                rendimientoTeorico={rendimientoTeorico}
+                onProcessChange={setProceso}
                 onValidityChange={setIsProcessValid}
             />
 

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -86,8 +86,11 @@ export interface ProcesoProduccionNode {
     targetIds: string[];
 }
 
-export interface ProcesoProduccionCompleto {
+export interface ProcesoDiseñado {
     procesosProduccion: ProcesoProduccionNode[];
+}
+
+export interface ProcesoProduccionCompleto extends ProcesoDiseñado {
     rendimientoTeorico: number;
 }
 


### PR DESCRIPTION
## Summary
- decouple process designer from rendimientoTeorico and propagate designed process via callback
- handle rendimientoTeorico in step three and combine before saving
- introduce ProcesoDiseñado type and extend ProcesoProduccionCompleto

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 132 problems (93 errors, 39 warnings))*
- `npx eslint src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepThree/StepThree.tsx src/pages/Productos/types.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a65009ec9883328a8cb3473f82b408