### PR TITLE
Enable loose click connections in process designer

### DIFF
--- a/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
+++ b/src/pages/Productos/DefProcesses/CreadorProcesos/ProcessDesigner.tsx
@@ -12,6 +12,7 @@ import {
     useEdgesState,
     Connection,
     addEdge,
+    ConnectionMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import MaterialPrimarioNode from "./Nodos/MaterialPrimarioNode.tsx";
@@ -287,6 +288,8 @@ export default function ProcessDesigner({ semioter2, onProcessChange, onValidity
                     onConnect={onConnect}
                     nodeTypes={nodeTypes}
                     defaultEdgeOptions={defaultEdgeOptions}
+                    connectionMode={ConnectionMode.Loose}
+                    connectOnClick
                     onSelectionChange={({ nodes: selectedNodes, edges: selectedEdges }) => {
                         if (selectedNodes.length > 0) setSelectedElement(selectedNodes[0]);
                         else if (selectedEdges.length > 0) setSelectedElement(selectedEdges[0]);


### PR DESCRIPTION
## Summary
- import `ConnectionMode` from `@xyflow/react`
- allow loose, click-based connections in the process designer's `<ReactFlow>`

## Testing
- `npm run lint` *(fails: 132 problems, 93 errors, 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b2036fc8332a189a043f75ba128