### PR TITLE
feat: add grams unit option

### DIFF
--- a/src/pages/Productos/Basic/CodificarMaterialesTab.tsx
+++ b/src/pages/Productos/Basic/CodificarMaterialesTab.tsx
@@ -287,6 +287,7 @@ function CodificarMaterialesTab() {
                                 <option value={UNIDADES.KG}>{UNIDADES.KG}</option>
                                 <option value={UNIDADES.L}>{UNIDADES.L}</option>
                                 <option value={UNIDADES.U}>{UNIDADES.U}</option>
+                                <option value={UNIDADES.G}>{UNIDADES.G}</option>
                             </Select>
                             <FormControl flex="4" isRequired>
                                 <FormLabel>Cantidad por Unidad</FormLabel>

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepOne/StepOne.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepOne/StepOne.tsx
@@ -2,7 +2,7 @@
 import {
     Button,
     Flex, FormControl, FormLabel, GridItem, HStack, Input, Select, SimpleGrid, Textarea, useToast,
-    Spinner, Text, Alert, AlertIcon
+    Spinner, Text
 } from "@chakra-ui/react";
 import {useState, useEffect} from "react";
 import axios from 'axios';
@@ -245,6 +245,7 @@ export default function StepOne({setActiveStep, setSemioter, refreshCategorias =
                             <option value={UNIDADES.KG}>{UNIDADES.KG}</option>
                             <option value={UNIDADES.L}>{UNIDADES.L}</option>
                             <option value={UNIDADES.U}>{UNIDADES.U}</option>
+                            <option value={UNIDADES.G}>{UNIDADES.G}</option>
                         </Select>
                         <FormControl flex="4" isRequired>
                             <FormLabel>Contenido por envase</FormLabel>

--- a/src/pages/Productos/types.tsx
+++ b/src/pages/Productos/types.tsx
@@ -1,6 +1,6 @@
 
 export const TIPOS_PRODUCTOS = {materiaPrima: "M", semiTerminado:"S", terminado:"T"};
-export const UNIDADES = {L:"L", KG:"KG", U:"U"};
+export const UNIDADES = {L:"L", KG:"KG", U:"U", G:"G"};
 export const TIPOS_MATERIALES = {materiaPrima: 1, materialDeEmpaque: 2};
 export const IVA_VALUES = {'iva_0':0, 'iva_5':5,'iva_19':19, };
 


### PR DESCRIPTION
## Summary
- extend UNIDADES catalog with gram unit
- allow selecting grams when coding materials or semi/finished products

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: repo-wide lint errors)
- `npx eslint src/pages/Productos/types.tsx src/pages/Productos/Basic/CodificarMaterialesTab.tsx src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepOne/StepOne.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a74efdbd948332bae1bbbaab121585