### PR TITLE
refactor: compact material node layout

### DIFF
--- a/src/pages/Productos/DefProcesses/CreadorProcesos/Nodos/MaterialPrimarioNode.tsx
+++ b/src/pages/Productos/DefProcesses/CreadorProcesos/Nodos/MaterialPrimarioNode.tsx
@@ -1,72 +1,55 @@
-import {Handle, NodeProps, Position} from "@xyflow/react";
-import {Box, Flex, Text, Icon } from "@chakra-ui/react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
+import { Box, Flex, Text, Icon } from "@chakra-ui/react";
 
 import { PiCubeFocusThin } from "react-icons/pi";
 
 const handleStyle = {
-    width:"1.5em",
-    height:"1.5em",
-}
-
+  width: "1em",
+  height: "1em",
+};
 
 export default function MaterialPrimarioNode(props: NodeProps) {
+  const data = props.data;
 
-    const data = props.data;
-
-    return(
-        <Box
-            border={"2px solid black"}
-            transition="box-shadow 0.1s ease"
-            _hover={{ boxShadow: "0 0 10px green" }}
-            w={"15em"}
-        >
-            <Flex
-                direction={"column"}
-                gap={2}
-                align={"center"}
-            >
-                <Box
-                    flex={1}
-                    bgColor={"green.300"}
-                    w={"full"}
-                    p={"0.5em"}
-                >
-                    <Text fontWeight={"bold"}>
-                        {String(data.label)}
-                    </Text>
-                </Box>
-
-                <Icon w="4em" h="4em" color={"tomato"} as={PiCubeFocusThin} />
-
-                <Box  w={"1em"} h={"1em"} flex={5}>
-                    <Handle
-                        type={"source"}
-                        position={Position.Right}
-                        id={"i1"}
-                        style={handleStyle}
-                        isConnectable={true}
-                    />
-                </Box>
-
-                <Box
-                    flex={1}
-                    w={"full"}
-                    borderTop={"2px solid black"}
-                    pt={"0.5em"}
-                >
-                    <Text fontWeight={"bold"}>
-                        {` ${data.cantidad} ${data.tipo_unidad}`}
-                    </Text>
-                </Box>
-
-                <Box
-                    flex={1}
-                    bgColor={"green.300"}
-                    w={"full"}
-                >
-                    <Text fontWeight={"bold"}> Material Primario </Text>
-                </Box>
-            </Flex>
+  return (
+    <Box
+      border={"2px solid black"}
+      transition="box-shadow 0.1s ease"
+      _hover={{ boxShadow: "0 0 10px green" }}
+      w={"12em"}
+      p={"0.5em"}
+      position="relative"
+      textAlign="center"
+    >
+      <Flex direction={"column"} gap={1} align={"center"}>
+        <Box bgColor={"green.300"} w={"full"} p={"0.3em"}>
+          <Text fontWeight={"bold"}>{String(data.label)}</Text>
         </Box>
-    )
+
+        <Icon w="3em" h="3em" color={"tomato"} as={PiCubeFocusThin} />
+
+        <Text
+          fontWeight={"bold"}
+          borderTop={"2px solid black"}
+          w={"full"}
+          pt={"0.3em"}
+        >
+          {` ${data.cantidad} ${data.tipo_unidad}`}
+        </Text>
+
+        <Box bgColor={"green.300"} w={"full"} p={"0.3em"}>
+          <Text fontWeight={"bold"}> Material Primario </Text>
+        </Box>
+      </Flex>
+
+      <Handle
+        type={"source"}
+        position={Position.Right}
+        id={"i1"}
+        style={handleStyle}
+        isConnectable={true}
+      />
+    </Box>
+  );
 }
+


### PR DESCRIPTION
## Summary
- make MaterialPrimarioNode more compact while retaining information and hover styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found 91 errors, 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b9250aa8833298cd0879296e4fbb