### PR TITLE
feat: add accent color handling for product items

### DIFF
--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaBusqueda.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaBusqueda.tsx
@@ -14,29 +14,16 @@ import {
 } from "@chakra-ui/react";
 import { Producto } from "../../../types.tsx";
 
-// Icons (react-icons)
-import { BiTestTube } from "react-icons/bi";    // Materia Prima (M)
-import { FiLayers, FiPackage, FiPlus } from "react-icons/fi"; // Semi / Terminado / Add
+// Icons
+import { FiPlus } from "react-icons/fi";
+
+// Shared helpers
+import { metaPorTipo } from "./meta";
 
 interface ItemBandejaBusquedaProps {
     producto: Producto;
     onAddInsumo: (producto: Producto) => void;
 }
-
-type MetaTipo = {
-    label: string;
-    scheme: "teal" | "purple" | "orange" | "gray";
-    icon: React.ElementType;
-};
-
-const metaPorTipo = (tipo: string): MetaTipo => {
-    switch (tipo) {
-        case "M": return { label: "Materia prima", scheme: "teal",   icon: BiTestTube };
-        case "S": return { label: "Semiterminado", scheme: "purple", icon: FiLayers };
-        case "T": return { label: "Terminado",     scheme: "orange", icon: FiPackage };
-        default:  return { label: "Producto",      scheme: "gray",   icon: FiPackage };
-    }
-};
 
 const ItemBandejaBusqueda: React.FC<ItemBandejaBusquedaProps> = ({
                                                                      producto,
@@ -68,22 +55,22 @@ const ItemBandejaBusqueda: React.FC<ItemBandejaBusquedaProps> = ({
             _hover={{ boxShadow: "lg", transform: "translateY(-2px)" }}
         >
             {/* Acento vertical */}
-            <Box position="absolute" left={0} top={0} bottom={0} w="6px" bg={`${meta.scheme}.400`} />
+            <Box position="absolute" left={0} top={0} bottom={0} w="6px" bg={meta.accentColor} />
 
             <Flex align="center" gap={4} px={4} py={3}>
                 {/* Icono por tipo */}
                 <Box
-                    bg={`${meta.scheme}.50`}
+                    bg={meta.accentColor}
                     borderWidth="1px"
-                    borderColor={`${meta.scheme}.200`}
-                    color={`${meta.scheme}.600`}
+                    borderColor={meta.accentColor}
+                    color="white"
                     rounded="lg"
                     p={2.5}
                     minW="42px"
                     display="flex"
                     alignItems="center"
                     justifyContent="center"
-                    _groupHover={{ bg: `${meta.scheme}.100` }}
+                    _groupHover={{ bg: meta.accentColor }}
                 >
                     <Icon as={meta.icon} boxSize={5} />
                 </Box>

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaSeleccion.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/ItemBandejaSeleccion.tsx
@@ -20,29 +20,16 @@ import {
 import { Insumo } from "../../../types.tsx";
 
 // Icons
-import { BiTestTube } from "react-icons/bi";            // Materia Prima
-import { FiLayers, FiPackage, FiMinus } from "react-icons/fi"; // Semi / Terminado / Remove
+import { FiMinus } from "react-icons/fi";
+
+// Shared helpers
+import { metaPorTipo } from "./meta";
 
 interface ItemBandejaSeleccionProps {
     insumo: Insumo;
     onUpdateCantidad: (productoId: string, newCantidad: number) => void;
     onRemoveInsumo: (productoId: string) => void;
 }
-
-type MetaTipo = {
-    label: string;
-    scheme: "teal" | "purple" | "orange" | "gray";
-    icon: React.ElementType;
-};
-
-const metaPorTipo = (tipo: string): MetaTipo => {
-    switch (tipo) {
-        case "M": return { label: "Materia prima", scheme: "teal",   icon: BiTestTube };
-        case "S": return { label: "Semiterminado", scheme: "purple", icon: FiLayers };
-        case "T": return { label: "Terminado",     scheme: "orange", icon: FiPackage };
-        default:  return { label: "Producto",      scheme: "gray",   icon: FiPackage };
-    }
-};
 
 const ItemBandejaSeleccion: React.FC<ItemBandejaSeleccionProps> = ({
                                                                        insumo,
@@ -77,22 +64,22 @@ const ItemBandejaSeleccion: React.FC<ItemBandejaSeleccionProps> = ({
             _hover={{ boxShadow: "lg", transform: "translateY(-2px)" }}
         >
             {/* Acento vertical */}
-            <Box position="absolute" left={0} top={0} bottom={0} w="6px" bg={`${meta.scheme}.400`} />
+            <Box position="absolute" left={0} top={0} bottom={0} w="6px" bg={meta.accentColor} />
 
             <Flex align="center" gap={4} px={4} py={3}>
                 {/* Icono por tipo */}
                 <Box
-                    bg={`${meta.scheme}.50`}
+                    bg={meta.accentColor}
                     borderWidth="1px"
-                    borderColor={`${meta.scheme}.200`}
-                    color={`${meta.scheme}.600`}
+                    borderColor={meta.accentColor}
+                    color="white"
                     rounded="lg"
                     p={2.5}
                     minW="42px"
                     display="flex"
                     alignItems="center"
                     justifyContent="center"
-                    _groupHover={{ bg: `${meta.scheme}.100` }}
+                    _groupHover={{ bg: meta.accentColor }}
                 >
                     <Icon as={meta.icon} boxSize={5} />
                 </Box>

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/meta.ts
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/meta.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import { BiTestTube } from "react-icons/bi";
+import { FiLayers, FiPackage } from "react-icons/fi";
+
+export type MetaTipo = {
+    label: string;
+    scheme: "teal" | "purple" | "orange" | "gray" | "green";
+    icon: React.ElementType;
+    accentColor: string;
+};
+
+export const metaPorTipo = (tipo: string): MetaTipo => {
+    switch (tipo) {
+        case "M":
+            return { label: "Materia prima", scheme: "green", icon: BiTestTube, accentColor: "green.300" };
+        case "S":
+            return { label: "Semiterminado", scheme: "purple", icon: FiLayers, accentColor: "purple.300" };
+        case "T":
+            return { label: "Terminado", scheme: "orange", icon: FiPackage, accentColor: "orange.300" };
+        default:
+            return { label: "Producto", scheme: "gray", icon: FiPackage, accentColor: "gray.300" };
+    }
+};


### PR DESCRIPTION
## Summary
- add shared metadata helper with accentColor support
- switch item components to material/semiproduct accent colors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 130 problems, 91 errors, 39 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68a86ea133748332b28e412a99150919