### PR TITLE
feat: add SplitText animation component

### DIFF
--- a/src/components/SplitText.stories.tsx
+++ b/src/components/SplitText.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SplitText from './SplitText.tsx';
+
+export const Characters = () => {
+  return <SplitText text="Animate by characters" />;
+};
+
+export const Words = () => {
+  return <SplitText text="Animate by words example" type="words" delay={0.2} />;
+};

--- a/src/components/SplitText.tsx
+++ b/src/components/SplitText.tsx
@@ -1,0 +1,41 @@
+// src/components/SplitText.tsx
+import { Text, TextProps } from "@chakra-ui/react";
+import { motion } from "framer-motion";
+
+interface SplitTextProps extends TextProps {
+    /** Text to display */
+    text: string;
+    /** Split type: characters or words */
+    type?: "characters" | "words";
+    /** Delay between each item animation in seconds */
+    delay?: number;
+    /** Duration of each animation in seconds */
+    duration?: number;
+}
+
+export default function SplitText({
+    text,
+    type = "characters",
+    delay = 0.05,
+    duration = 0.4,
+    ...rest
+}: SplitTextProps) {
+    const parts = type === "words" ? text.split(" ") : Array.from(text);
+
+    return (
+        <Text as="h3" fontSize="xl" fontFamily="Comfortaa Variable" display="inline-block" {...rest}>
+            {parts.map((part, index) => (
+                <motion.span
+                    key={index}
+                    initial={{ opacity: 0, y: "0.25em" }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration, delay: index * delay }}
+                    style={{ display: "inline-block" }}
+                >
+                    {part}
+                    {type === "words" && index < parts.length - 1 ? " " : ""}
+                </motion.span>
+            ))}
+        </Text>
+    );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 // src/pages/Home.tsx
 import {SimpleGrid, Flex, Heading, Button, Spacer, Container, Text, Box, HStack, Tooltip} from "@chakra-ui/react";
 import SectionCard from "../components/SectionCard.tsx";
+import SplitText from "../components/SplitText.tsx";
 import { PiDownloadDuotone } from "react-icons/pi";
 import { BsDatabaseCheck } from "react-icons/bs";
 import { AiOutlineAudit } from "react-icons/ai";
@@ -65,9 +66,7 @@ export default function Home(){
                         alignContent={'center'}
                     >
                         <Box transform="skewX(10deg)">
-                            <Text as="h3" size="xl" fontFamily="Comfortaa Variable">
-                                Version: Beta 1.1
-                            </Text>
+                            <SplitText text="Version: Beta 1.1" />
                         </Box>
                     </Box>
 


### PR DESCRIPTION
## Summary
- add reusable SplitText component that animates text by character or word
- replace static version label on home page with animated SplitText
- showcase SplitText animation in a new Ladle story

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-storybook")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4abe0788332ac3af01f1b37ab6c