### PR TITLE
feat: trigger search on Enter in product forms

### DIFF
--- a/src/pages/Productos/Basic/InformeProductosTab.tsx
+++ b/src/pages/Productos/Basic/InformeProductosTab.tsx
@@ -96,6 +96,11 @@ export default function InformeProductosTab() {
                         onChange={(e) => setSearchText(e.target.value)}
                         placeholder="Enter product name"
                         isDisabled={chkbox.length === 0}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                handleSearch();
+                            }
+                        }}
                     />
                 </FormControl>
 

--- a/src/pages/Productos/DefProcesses/AFpickerRP.tsx
+++ b/src/pages/Productos/DefProcesses/AFpickerRP.tsx
@@ -71,10 +71,19 @@ export default function AFpickerRP({isOpen, onClose, onConfirm, alreadySelected}
           <Flex gap={4}>
             <Box flex={1}>
               <Flex mb={2} gap={2}>
-                <Input placeholder='Buscar' value={searchText} onChange={(e)=>setSearchText(e.target.value)} />
-                <Button 
-                  onClick={()=>fetchAvailable(0)} 
-                  isLoading={loading} 
+                <Input
+                  placeholder='Buscar'
+                  value={searchText}
+                  onChange={(e)=>setSearchText(e.target.value)}
+                  onKeyDown={(e)=>{
+                    if(e.key==='Enter'){
+                      fetchAvailable(0);
+                    }
+                  }}
+                />
+                <Button
+                  onClick={()=>fetchAvailable(0)}
+                  isLoading={loading}
                   loadingText="Buscando..."
                 >
                   Buscar

--- a/src/pages/Productos/DefProcesses/ConsultaRecursosProduccion.tsx
+++ b/src/pages/Productos/DefProcesses/ConsultaRecursosProduccion.tsx
@@ -64,7 +64,15 @@ function PanelBusqueda({setEstado,setRecursoSel,setRefreshFn}:PanelProps){
         <Flex gap={4} alignItems="end">
           <FormControl flex={2}>
             <FormLabel>{searchType===TipoBusqueda.ID? 'ID' : 'Nombre'}</FormLabel>
-            <Input value={searchText} onChange={e=>setSearchText(e.target.value)} />
+            <Input
+              value={searchText}
+              onChange={e=>setSearchText(e.target.value)}
+              onKeyDown={(e)=>{
+                if(e.key==='Enter'){
+                  handleSearch();
+                }
+              }}
+            />
           </FormControl>
           <FormControl flex={1}>
             <FormLabel>Tipo de Búsqueda</FormLabel>

--- a/src/pages/Productos/DefProcesses/CreadorProcesos/components/ProcesoProduccionPicker/ProcesoProduccionPicker.tsx
+++ b/src/pages/Productos/DefProcesses/CreadorProcesos/components/ProcesoProduccionPicker/ProcesoProduccionPicker.tsx
@@ -118,10 +118,15 @@ export function ProcesoProduccionPicker({isOpen, onClose, onConfirm, alreadySele
             {/* Panel izquierdo - Procesos disponibles */}
             <Box flex={1}>
               <Flex mb={2} gap={2}>
-                <Input 
-                  placeholder='Buscar por nombre' 
-                  value={searchText} 
-                  onChange={(e) => setSearchText(e.target.value)} 
+                <Input
+                  placeholder='Buscar por nombre'
+                  value={searchText}
+                  onChange={(e) => setSearchText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      fetchAvailable(0);
+                    }
+                  }}
                 />
                 <Button
                   onClick={() => fetchAvailable(0)}

--- a/src/pages/Productos/DefProcesses/RecursoProduccionPicker.tsx
+++ b/src/pages/Productos/DefProcesses/RecursoProduccionPicker.tsx
@@ -71,7 +71,16 @@ export default function RecursoProduccionPicker({isOpen, onClose, onConfirm, alr
           <Flex gap={4}>
             <Box flex={1}>
               <Flex mb={2} gap={2}>
-                <Input placeholder='Buscar' value={searchText} onChange={(e)=>setSearchText(e.target.value)} />
+                <Input
+                  placeholder='Buscar'
+                  value={searchText}
+                  onChange={(e)=>setSearchText(e.target.value)}
+                  onKeyDown={(e)=>{
+                    if(e.key==='Enter'){
+                      fetchAvailable(0);
+                    }
+                  }}
+                />
                 <Button
                   onClick={()=>fetchAvailable(0)}
                   isLoading={loading}

--- a/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/BandejaBusqueda.tsx
+++ b/src/pages/Productos/DefSemiTer/CodificarSemioTermiTab/StepTwo/BandejaBusqueda.tsx
@@ -71,6 +71,11 @@ const BandejaBusqueda: React.FC<BandejaBusquedaProps> = ({ onAddInsumo }) => {
                             value={searchString}
                             onChange={(e) => setSearchString(e.target.value)}
                             placeholder="Ingrese término de búsqueda..."
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    handleSearch(0);
+                                }
+                            }}
                         />
                     </FormControl>
                     <Button colorScheme="teal" onClick={() => handleSearch(0)}>


### PR DESCRIPTION
## Summary
- trigger search when pressing Enter in product search fields across various components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint found errors)
- manually verified pressing Enter triggers search in each form


------
https://chatgpt.com/codex/tasks/task_e_68a8c54584bc83329bdb6716c3a71596