### PR TITLE
Add observations support to purchase orders

### DIFF
--- a/src/pages/ActivosFijos/types.tsx
+++ b/src/pages/ActivosFijos/types.tsx
@@ -125,6 +125,7 @@ export interface OrdenCompraActivo {
     tiempoEntrega: string;
     plazoPago: number;
     cotizacionUrl?: string; // la asigna el backend cuando se adjunta la cotizacion en pdf (multipartfile)
+    observaciones?: string;
     /**
      * -1: cancelada
      *  0: pendiente liberacion

--- a/src/pages/Compras/CrearOCM.tsx
+++ b/src/pages/Compras/CrearOCM.tsx
@@ -1,6 +1,6 @@
 // ./CrearOrdenCompra.tsx
 import { useState } from 'react';
-import {Button, Container, Flex, FormControl, FormLabel, Input, Select, useToast, Text} from '@chakra-ui/react';
+import {Button, Container, Flex, FormControl, FormLabel, Input, Select, Textarea, useToast, Text} from '@chakra-ui/react';
 import axios from 'axios';
 import { Proveedor, Material, ItemOrdenCompra, OrdenCompraMateriales, DIVISAS } from './types';
 import EndPointsURL from '../../api/EndPointsURL';
@@ -26,6 +26,7 @@ export default function CrearOCM() {
     const [condicionPago, setCondicionPago] = useState("0");
     const [tiempoEntrega, setTiempoEntrega] = useState("15");
     const [fechaVencimiento, setFechaVencimiento] = useState(format(addDays(new Date(), 30), "yyyy-MM-dd"));
+    const [observaciones, setObservaciones] = useState("");
 
     const [subTotal, setSubTotal] = useState(0);
     const [iva19, setIva19] = useState(0);
@@ -63,6 +64,7 @@ export default function CrearOCM() {
         updateTotalesAndGetValues();
         setIsUSD(false);
         setCurrentUsd2Cop(0);
+        setObservaciones("");
     };
 
     const checkCantidades = () => {
@@ -196,6 +198,7 @@ export default function CrearOCM() {
             condicionPago: condicionPago,
             tiempoEntrega: tiempoEntrega,
             plazoPago: plazoPago,
+            observaciones: observaciones,
             estado: 0, // 0 = pendiente aprobación proveedor
             divisas: isUSD ? DIVISAS.USD : DIVISAS.COP,
             trm: isUSD ? currentUsd2Cop : 1, // When COP is selected, TRM should be 1
@@ -298,6 +301,15 @@ export default function CrearOCM() {
                         />
 
                     </Flex>
+
+                    <FormControl mt={2}>
+                        <FormLabel>Observaciones</FormLabel>
+                        <Textarea
+                            value={observaciones}
+                            onChange={(e) => setObservaciones(e.target.value)}
+                            placeholder="Ingrese observaciones"
+                        />
+                    </FormControl>
 
                 </Flex>
 

--- a/src/pages/Compras/components/EditarOCMSeleccionada.tsx
+++ b/src/pages/Compras/components/EditarOCMSeleccionada.tsx
@@ -9,7 +9,8 @@ import {
     FormControl,
     FormLabel,
     Input,
-    Select
+    Select,
+    Textarea
 } from '@chakra-ui/react';
 import { OrdenCompraMateriales, ItemOrdenCompra, Material, DIVISAS } from "../types.tsx";
 import MateriaPrimaPicker from './MateriaPrimaPicker.tsx';
@@ -26,8 +27,12 @@ type Props = {
 };
 
 export function EditarOcmSeleccionada({ ocm, onVolver }: Props) {
-    const [ordenActual, setOrdenActual] = useState<OrdenCompraMateriales>({...ocm});
+    const [ordenActual, setOrdenActual] = useState<OrdenCompraMateriales>({
+        ...ocm,
+        observaciones: ocm.observaciones || "",
+    });
     const [listaItemsOrdenCompra, setListaItemsOrdenCompra] = useState<ItemOrdenCompra[]>(ocm.itemsOrdenCompra);
+    const [observaciones, setObservaciones] = useState(ocm.observaciones || "");
     const [isMateriaPrimaPickerOpen, setIsMateriaPrimaPickerOpen] = useState(false);
     const [ivaEnabled, setIvaEnabled] = useState(true);
     const [isFormValid, setIsFormValid] = useState(false);
@@ -109,9 +114,10 @@ export function EditarOcmSeleccionada({ ocm, onVolver }: Props) {
             condicionPago: ocm.condicionPago || "0",
             plazoPago: ocm.plazoPago || 30,
             tiempoEntrega: ocm.tiempoEntrega || "15",
-            fechaVencimiento: ocm.fechaVencimiento 
+            fechaVencimiento: ocm.fechaVencimiento
                 ? format(new Date(ocm.fechaVencimiento), "yyyy-MM-dd") + "T00:00:00"
-                : format(new Date(), "yyyy-MM-dd") + "T00:00:00"
+                : format(new Date(), "yyyy-MM-dd") + "T00:00:00",
+            observaciones: ocm.observaciones || "",
         };
 
         const currentOrder = {
@@ -159,6 +165,7 @@ export function EditarOcmSeleccionada({ ocm, onVolver }: Props) {
             plazoPago: plazoPago,
             tiempoEntrega: tiempoEntrega,
             fechaVencimiento: fechaVencimiento + "T00:00:00",
+            observaciones: observaciones,
             // Actualizar moneda y TRM
             divisas: isUSD ? DIVISAS.USD : DIVISAS.COP,
             trm: isUSD ? currentUsd2Cop : 1 // When COP is selected, TRM should be 1
@@ -273,6 +280,15 @@ export function EditarOcmSeleccionada({ ocm, onVolver }: Props) {
         setOrdenActual(prev => ({
             ...prev,
             fechaVencimiento: date + "T00:00:00"
+        }));
+    };
+
+    const handleObservacionesChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const value = e.target.value;
+        setObservaciones(value);
+        setOrdenActual(prev => ({
+            ...prev,
+            observaciones: value,
         }));
     };
 
@@ -396,6 +412,15 @@ export function EditarOcmSeleccionada({ ocm, onVolver }: Props) {
                     label={"Fecha de Vencimiento Orden"}
                 />
             </Flex>
+
+            <FormControl>
+                <FormLabel>Observaciones</FormLabel>
+                <Textarea
+                    value={observaciones}
+                    onChange={handleObservacionesChange}
+                    placeholder="Ingrese observaciones"
+                />
+            </FormControl>
 
             <Button colorScheme="blue" onClick={() => setIsMateriaPrimaPickerOpen(true)}>
                 Agregar Material

--- a/src/pages/Compras/components/OrdenCompraDetails.tsx
+++ b/src/pages/Compras/components/OrdenCompraDetails.tsx
@@ -54,6 +54,7 @@ const OrdenCompraDetails: React.FC<OrdenCompraDetailsProps> = ({ isOpen, onClose
                         <Text><strong>Condición de Pago:</strong> {getCondicionPagoText(orden.condicionPago)}</Text>
                         <Text><strong>Tiempo de Entrega:</strong> {orden.tiempoEntrega}</Text>
                         <Text><strong>Plazo de Pago:</strong> {orden.plazoPago}</Text>
+                        <Text><strong>Observaciones:</strong> {orden.observaciones || '-'}</Text>
                     </Box>
                     <Box>
                         <Text fontWeight="bold" mb={2}>Items de la Orden</Text>

--- a/src/pages/Compras/pdfGenerator.tsx
+++ b/src/pages/Compras/pdfGenerator.tsx
@@ -212,11 +212,14 @@ export default class PdfGenerator {
         totalsY += leyendaLines.length * 4;
 
         // --- Observaciones ---
-        // doc.setFont("helvetica", "bold");
-        // doc.text("OBSERVACIONES", margin, totalsY);
-        // totalsY += 5;
-        // doc.rect(margin, totalsY, 190, 20); // a smaller rectangle for observations
-        //
+        doc.setFont("helvetica", "bold");
+        doc.text("OBSERVACIONES", margin, totalsY);
+        totalsY += 5;
+        doc.setFont("helvetica", "normal");
+        const obs = orden.observaciones ? orden.observaciones : "";
+        const obsLines = doc.splitTextToSize(obs, 190);
+        doc.text(obsLines, margin, totalsY);
+        totalsY += obsLines.length * 4;
 
         // --- Trigger Download ---
         //doc.save(`orden-compra-${orden.ordenCompraId}.pdf`);
@@ -438,11 +441,14 @@ export default class PdfGenerator {
         totalsY += leyendaLines.length * 4;
 
         // --- Observaciones ---
-        // doc.setFont("helvetica", "bold");
-        // doc.text("OBSERVACIONES", margin, totalsY);
-        // totalsY += 5;
-        // doc.rect(margin, totalsY, 190, 20); // a smaller rectangle for observations
-        //
+        doc.setFont("helvetica", "bold");
+        doc.text("OBSERVACIONES", margin, totalsY);
+        totalsY += 5;
+        doc.setFont("helvetica", "normal");
+        const obs = orden.observaciones ? orden.observaciones : "";
+        const obsLines = doc.splitTextToSize(obs, 190);
+        doc.text(obsLines, margin, totalsY);
+        totalsY += obsLines.length * 4;
 
         // --- Trigger Download ---
         doc.save(`orden-compra-${orden.ordenCompraActivoId}.pdf`);

--- a/src/pages/Compras/types.tsx
+++ b/src/pages/Compras/types.tsx
@@ -97,6 +97,7 @@ export interface OrdenCompraMateriales {
     condicionPago: string;
     tiempoEntrega: string;
     plazoPago: number;
+    observaciones?: string;
     /**
      * -1: cancelada
      *  0: pendiente liberacion


### PR DESCRIPTION
## Summary
- allow recording "Observaciones" on purchase orders
- show existing observations in order details and edit view
- include observations in generated PDF

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint found 97 errors, 39 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3bdeff4833288cfac0ffd028819