### PR TITLE
feat: add master directives context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ window.REACT_ROUTER_SILENT_DEPRECATIONS = true;
 import RootLayout from "./pages/RootLayout.tsx";
 import Home from "./pages/Home.tsx"
 import { NotificationsProvider } from "./context/NotificationsContext.tsx";
+import { MasterDirectivesProvider } from "./context/MasterDirectivesContext.tsx";
 import ProductosPage from './pages/Productos/ProductosPage.tsx'
 import StockPage from "./pages/Stock/StockPage.tsx";
 import ProduccionPage from "./pages/Produccion/ProduccionPage.tsx";
@@ -259,9 +260,11 @@ const router = createBrowserRouter(
 
 function App() {
     return (
-        <NotificationsProvider>
-            <RouterProvider router={router} />
-        </NotificationsProvider>
+        <MasterDirectivesProvider>
+            <NotificationsProvider>
+                <RouterProvider router={router} />
+            </NotificationsProvider>
+        </MasterDirectivesProvider>
     )
 }
 

--- a/src/context/MasterDirectivesContext.tsx
+++ b/src/context/MasterDirectivesContext.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useContext, useEffect, useMemo, useState, ReactNode } from "react";
+import axios from "axios";
+import EndPointsURL from "../api/EndPointsURL";
+
+interface MasterDirective {
+    nombre: string;
+    valor: string;
+    tipoDato: "TEXTO" | "NUMERO" | "DECIMAL" | "BOOLEANO" | "FECHA" | "JSON";
+}
+
+interface DTOAllMasterDirectives {
+    masterDirectives: MasterDirective[];
+}
+
+type MasterDirectivesMap = Record<string, unknown>;
+
+const MasterDirectivesContext = createContext<MasterDirectivesMap>({});
+
+export function MasterDirectivesProvider({ children }: { children: ReactNode }) {
+    const [directives, setDirectives] = useState<MasterDirectivesMap>({});
+    const endPoints = useMemo(() => new EndPointsURL(), []);
+
+    useEffect(() => {
+        const fetchDirectives = async () => {
+            try {
+                const res = await axios.get<DTOAllMasterDirectives>(endPoints.get_master_directives);
+                const map: MasterDirectivesMap = {};
+                res.data.masterDirectives.forEach(md => {
+                    let value: unknown = md.valor;
+                    switch (md.tipoDato) {
+                        case "BOOLEANO":
+                            value = md.valor === "true";
+                            break;
+                        case "NUMERO":
+                            value = parseInt(md.valor, 10);
+                            break;
+                        case "DECIMAL":
+                            value = parseFloat(md.valor);
+                            break;
+                        case "JSON":
+                            try {
+                                value = JSON.parse(md.valor);
+                            } catch {
+                                value = md.valor;
+                            }
+                            break;
+                        default:
+                            value = md.valor;
+                    }
+                    map[md.nombre] = value;
+                });
+                setDirectives(map);
+            } catch (error) {
+                console.error("Error fetching master directives", error);
+            }
+        };
+        fetchDirectives();
+    }, [endPoints]);
+
+    return (
+        <MasterDirectivesContext.Provider value={directives}>
+            {children}
+        </MasterDirectivesContext.Provider>
+    );
+}
+
+export function useMasterDirectives() {
+    return useContext(MasterDirectivesContext);
+}
+

--- a/src/pages/TransaccionesAlmacen/TransaccionesAlmacenPage.tsx
+++ b/src/pages/TransaccionesAlmacen/TransaccionesAlmacenPage.tsx
@@ -4,9 +4,13 @@ import AsistenteIngresoMercancia from "./AsistenteIngresoOCM/AsistenteIngresoMer
 import {AsistenteDispensacion} from "./AsistenteDispensacion/AsistenteDispensacion.tsx";
 import {AsistenteDispensacionDirecta} from "./AsistenteDispensacionDirecta/AsistenteDispensacionDirecta.tsx";
 import {AsistenteBackflushDirecto} from "./AsistenteBackflushDirecto/AsistenteBackflushDirecto.tsx";
+import { useMasterDirectives } from "../../context/MasterDirectivesContext.tsx";
 
 
 export default function TransaccionesAlmacenPage(){
+    const directives = useMasterDirectives();
+    const showDispensacionDirecta = directives["Permitir Consumo No Planificado"] === true;
+    const showBackflushDirecto = directives["Permitir Backflush No Planificado"] === true;
 
     return(
         <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
@@ -16,8 +20,8 @@ export default function TransaccionesAlmacenPage(){
                     <Tab> Ingreso OCM </Tab>
                     <Tab> Dispensacion </Tab>
                     <Tab> Ingreso Producto Terminado </Tab>
-                    <Tab> Dispensacion Directa (provisional) </Tab>
-                    <Tab> Backflush Directo (provisional) </Tab>
+                    {showDispensacionDirecta && <Tab> Dispensacion Directa (provisional) </Tab>}
+                    {showBackflushDirecto && <Tab> Backflush Directo (provisional) </Tab>}
                 </TabList>
                 <TabPanels>
 
@@ -33,13 +37,17 @@ export default function TransaccionesAlmacenPage(){
                         <AsistenteIngresoMercancia />
                     </TabPanel>
 
-                    <TabPanel>
-                        <AsistenteDispensacionDirecta />
-                    </TabPanel>
+                    {showDispensacionDirecta && (
+                        <TabPanel>
+                            <AsistenteDispensacionDirecta />
+                        </TabPanel>
+                    )}
 
-                    <TabPanel>
-                        <AsistenteBackflushDirecto />
-                    </TabPanel>
+                    {showBackflushDirecto && (
+                        <TabPanel>
+                            <AsistenteBackflushDirecto />
+                        </TabPanel>
+                    )}
 
                 </TabPanels>
             </Tabs>


### PR DESCRIPTION
## Summary
- load master directives on app start via new context
- conditionally show direct dispensacion and backflush tabs

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: module resolution and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e77d11f08332ac7ae55951db67e3