### PR TITLE
Add inventory export and styling

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -72,6 +72,7 @@ export default class EndPointsURL{
     public search_products_with_stock:string;
     public get_movimientos_by_producto:string;
     public exportar_movimientos_excel: string;
+    public exportar_inventario_excel: string;
 
     public save_doc_ingreso_oc: string;
 
@@ -219,6 +220,7 @@ export default class EndPointsURL{
         this.search_products_with_stock = `${domain}/${movimientos_res}/search_products_with_stock`;
         this.get_movimientos_by_producto = `${domain}/${movimientos_res}/get_movimientos_by_producto`;
         this.exportar_movimientos_excel = `${domain}/${movimientos_res}/exportar-movimientos-excel`;
+        this.exportar_inventario_excel = `${domain}/inventario/exportar-excel`;
 
         this.save_doc_ingreso_oc = `${domain}/${movimientos_res}/save_doc_ingreso_oc`;
 

--- a/src/pages/Stock/Inventario.tsx
+++ b/src/pages/Stock/Inventario.tsx
@@ -77,6 +77,25 @@ function Inventario() {
         setPageProductos(page);
     };
 
+    const handleDownloadInventario = async () => {
+        try {
+            const response = await axios.post(
+                endPoints.exportar_inventario_excel,
+                { categories: [], searchTerm },
+                { responseType: 'blob' }
+            );
+            const url = window.URL.createObjectURL(new Blob([response.data]));
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', 'inventario.xlsx');
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+        } catch (error) {
+            console.error('Error downloading Excel:', error);
+        }
+    };
+
     return (
         <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'} >
                 <VStack h={'full'} w={'full'} >
@@ -100,6 +119,7 @@ function Inventario() {
                                         setPageProductos(0);
                                         handleSearch();
                                     }}>Buscar</Button>
+                                    <Button colorScheme="teal" onClick={handleDownloadInventario}>Reporte inventario</Button>
                                 </HStack>
                             </FormControl>
                             <Box w={"full"} mt={4}>

--- a/src/pages/Stock/ListaProductos.tsx
+++ b/src/pages/Stock/ListaProductos.tsx
@@ -88,7 +88,7 @@ function ListaProductos({
                                             <Td>{item.producto.tipoUnidades}</Td>
                                             <Td>
                                                 <Menu>
-                                                    <MenuButton as={Button} size="sm">Menu</MenuButton>
+                                                    <MenuButton as={Button} size="sm" colorScheme="teal">Menu</MenuButton>
                                                     <MenuList>
                                                         <MenuItem onClick={() => handleDownloadExcel(item.producto.productoId)}>
                                                             Descargar Excel de movimientos


### PR DESCRIPTION
## Summary
- style product menu buttons with teal color scheme
- expose inventory Excel export endpoint
- add inventory report download button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68add1a73190833287bb005a6130117f