### PR TITLE
fix: correct inventory search pagination

### DIFF
--- a/src/pages/Stock/Inventario.tsx
+++ b/src/pages/Stock/Inventario.tsx
@@ -33,14 +33,14 @@ function Inventario() {
     const [totalPagesProductos, setTotalPagesProductos] = useState(0);
     const [loadingProductos, setLoadingProductos] = useState(false);
 
-    const handleSearch = async () => {
+    const handleSearch = async (page = pageProductos) => {
         setLoadingProductos(true);
         try {
             const response = await axios.get(endPoints.search_products_with_stock, {
                 params: {
                     searchTerm,
                     tipoBusqueda,
-                    page: pageProductos,
+                    page,
                     size: 10,
                 },
             });
@@ -62,19 +62,20 @@ function Inventario() {
 
     useEffect(() => {
         if (searchTerm !== '') {
-            handleSearch();
+            handleSearch(pageProductos);
         }
     }, [pageProductos]);
 
     const onKeyPress_InputBuscar = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'Enter') {
+            handleSearch(0);
             setPageProductos(0);
-            handleSearch();
         }
     };
 
     const handlePageChangeProductos = (page: number) => {
         setPageProductos(page);
+        handleSearch(page);
     };
 
     const handleDownloadInventario = async () => {
@@ -116,8 +117,8 @@ function Inventario() {
                                         <option value="ID">ID</option>
                                     </Select>
                                     <Button onClick={() => {
+                                        handleSearch(0);
                                         setPageProductos(0);
-                                        handleSearch();
                                     }}>Buscar</Button>
                                     <Button colorScheme="teal" onClick={handleDownloadInventario}>Reporte inventario</Button>
                                 </HStack>


### PR DESCRIPTION
## Summary
- ensure inventory searches send the proper page index
- reset to first page on new search and fetch selected pages immediately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module 'storybook/internal/csf')*

------
https://chatgpt.com/codex/tasks/task_e_68add40ded9083328f2836afcba98fcf