### PR TITLE
feat(stock): add date range modal for excel

### DIFF
--- a/src/pages/Stock/ListaProductos.tsx
+++ b/src/pages/Stock/ListaProductos.tsx
@@ -1,13 +1,15 @@
-
 import {
     Box, Spinner, Text,
     Table, Thead, Tbody, Tr, Th, Td, Flex,
-    Menu, MenuButton, MenuList, MenuItem, Button
+    Menu, MenuButton, MenuList, MenuItem, Button,
+    useDisclosure
 } from "@chakra-ui/react";
+import { useState } from 'react';
 import axios from 'axios';
 import EndPointsURL from "../../api/EndPointsURL.tsx";
 import { ProductStockDTO } from './types.tsx';
 import MyPagination from '../../components/MyPagination';
+import MovimientosExcelModal from './MovimientosExcelModal';
 
 const endPoints = new EndPointsURL();
 
@@ -19,6 +21,12 @@ interface ListaProductosProps {
     handlePageChangeProductos: (page: number) => void;
 }
 
+/**
+ * Displays the product stock table and allows exporting movement history to Excel.
+ *
+ * When the user chooses to export, a modal is presented to capture the desired
+ * date range before generating the file.
+ */
 function ListaProductos({
     productos,
     loadingProductos,
@@ -26,14 +34,20 @@ function ListaProductos({
     totalPagesProductos,
     handlePageChangeProductos
 }: ListaProductosProps) {
-    const handleDownloadExcel = async (productoId: number) => {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+    const [selectedProductId, setSelectedProductId] = useState<number | null>(null);
+
+    /**
+     * Requests the Excel file for a product within the provided date range.
+     */
+    const handleDownloadExcel = async (productoId: number, start: string, end: string) => {
         try {
             const response = await axios.post(
                 endPoints.exportar_movimientos_excel,
                 {
                     productoId: productoId.toString(),
-                    startDate: '1970-01-01',
-                    endDate: new Date().toISOString().split('T')[0],
+                    startDate: start,
+                    endDate: end,
                 },
                 { responseType: 'blob' }
             );
@@ -49,68 +63,87 @@ function ListaProductos({
         }
     };
 
+    /**
+     * Receives the date range selected in the modal and triggers the export.
+     */
+    const handleConfirmDownload = async (start: string, end: string) => {
+        if (selectedProductId) {
+            await handleDownloadExcel(selectedProductId, start, end);
+        }
+    };
+
     return (
-        <Flex
-            direction={"column"}
-            flex={1}
-            w={"full"}
-            mr={{ base: 0, md: 4 }}
-            mb={{ base: 4, md: 0 }}
-        >
-            {loadingProductos ? (
-                <Spinner />
-            ) : (
-                <>
-                    <Box w={"full"}>
-                        <Table variant="striped" colorScheme="gray" size="sm" width="100%">
-                            <Thead position="sticky" top={0} bg="white" zIndex={1}>
-                                <Tr>
-                                    <Th>ID</Th>
-                                    <Th>Nombre</Th>
-                                    <Th>Stock</Th>
-                                    <Th>Unidades</Th>
-                                    <Th>Menu</Th>
-                                </Tr>
-                            </Thead>
-                            <Tbody>
-                                {productos.length === 0 ? (
+        <>
+            <Flex
+                direction={"column"}
+                flex={1}
+                w={"full"}
+                mr={{ base: 0, md: 4 }}
+                mb={{ base: 4, md: 0 }}
+            >
+                {loadingProductos ? (
+                    <Spinner />
+                ) : (
+                    <>
+                        <Box w={"full"}>
+                            <Table variant="striped" colorScheme="gray" size="sm" width="100%">
+                                <Thead position="sticky" top={0} bg="white" zIndex={1}>
                                     <Tr>
-                                        <Td colSpan={5} textAlign="center">
-                                            <Text py={2}>No se encontraron productos.</Text>
-                                        </Td>
+                                        <Th>ID</Th>
+                                        <Th>Nombre</Th>
+                                        <Th>Stock</Th>
+                                        <Th>Unidades</Th>
+                                        <Th>Menu</Th>
                                     </Tr>
-                                ) : (
-                                    productos.map((item) => (
-                                        <Tr key={item.producto.productoId}>
-                                            <Td>{item.producto.productoId}</Td>
-                                            <Td>{item.producto.nombre}</Td>
-                                            <Td>{item.stock}</Td>
-                                            <Td>{item.producto.tipoUnidades}</Td>
-                                            <Td>
-                                                <Menu>
-                                                    <MenuButton as={Button} size="sm" colorScheme="teal">Menu</MenuButton>
-                                                    <MenuList>
-                                                        <MenuItem onClick={() => handleDownloadExcel(item.producto.productoId)}>
-                                                            Descargar Excel de movimientos
-                                                        </MenuItem>
-                                                    </MenuList>
-                                                </Menu>
+                                </Thead>
+                                <Tbody>
+                                    {productos.length === 0 ? (
+                                        <Tr>
+                                            <Td colSpan={5} textAlign="center">
+                                                <Text py={2}>No se encontraron productos.</Text>
                                             </Td>
                                         </Tr>
-                                    ))
-                                )}
-                            </Tbody>
-                        </Table>
-                    </Box>
-                    <MyPagination
-                        page={pageProductos}
-                        totalPages={totalPagesProductos}
-                        loading={loadingProductos}
-                        handlePageChange={handlePageChangeProductos}
-                    />
-                </>
-            )}
-        </Flex>
+                                    ) : (
+                                        productos.map((item) => (
+                                            <Tr key={item.producto.productoId}>
+                                                <Td>{item.producto.productoId}</Td>
+                                                <Td>{item.producto.nombre}</Td>
+                                                <Td>{item.stock}</Td>
+                                                <Td>{item.producto.tipoUnidades}</Td>
+                                                <Td>
+                                                    <Menu>
+                                                        <MenuButton as={Button} size="sm" colorScheme="teal">Menu</MenuButton>
+                                                        <MenuList>
+                                                            <MenuItem onClick={() => {
+                                                                setSelectedProductId(item.producto.productoId);
+                                                                onOpen();
+                                                            }}>
+                                                                Descargar Excel de movimientos
+                                                            </MenuItem>
+                                                        </MenuList>
+                                                    </Menu>
+                                                </Td>
+                                            </Tr>
+                                        ))
+                                    )}
+                                </Tbody>
+                            </Table>
+                        </Box>
+                        <MyPagination
+                            page={pageProductos}
+                            totalPages={totalPagesProductos}
+                            loading={loadingProductos}
+                            handlePageChange={handlePageChangeProductos}
+                        />
+                    </>
+                )}
+            </Flex>
+            <MovimientosExcelModal
+                isOpen={isOpen}
+                onClose={onClose}
+                onConfirm={handleConfirmDownload}
+            />
+        </>
     );
 }
 

--- a/src/pages/Stock/MovimientosExcelModal.tsx
+++ b/src/pages/Stock/MovimientosExcelModal.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    ModalCloseButton,
+    FormControl,
+    FormLabel,
+    Input,
+    Button
+} from '@chakra-ui/react';
+
+/**
+ * Modal for selecting a date range before exporting product movements.
+ *
+ * Validates that both dates are provided and that the start date is not
+ * greater than the end date before enabling the confirmation button.
+ */
+interface MovimientosExcelModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (startDate: string, endDate: string) => void;
+}
+
+function MovimientosExcelModal({ isOpen, onClose, onConfirm }: MovimientosExcelModalProps) {
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+
+    const isDownloadDisabled = !startDate || !endDate || startDate > endDate;
+
+    // Reset the date fields each time the modal is opened to provide a clean state.
+    useEffect(() => {
+        if (isOpen) {
+            setStartDate('');
+            setEndDate('');
+        }
+    }, [isOpen]);
+
+    const handleConfirm = () => {
+        onConfirm(startDate, endDate);
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} isCentered>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Seleccionar rango de fechas</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <FormControl>
+                        <FormLabel>Fecha inicio</FormLabel>
+                        <Input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+                    </FormControl>
+                    <FormControl mt={4}>
+                        <FormLabel>Fecha fin</FormLabel>
+                        <Input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+                    </FormControl>
+                </ModalBody>
+                <ModalFooter>
+                    <Button mr={3} onClick={onClose}>Cancelar</Button>
+                    <Button colorScheme="teal" onClick={handleConfirm} isDisabled={isDownloadDisabled}>
+                        Descargar
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+}
+
+export default MovimientosExcelModal;
+


### PR DESCRIPTION
## Summary
- extract date range modal into reusable component for exporting stock movements
- document list and modal components with comment blocks for easier context

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ade84fef588332b1e71d469919f45b