### PR TITLE
feat: add unplanned dispensing wizard

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -75,6 +75,9 @@ export default class EndPointsURL{
 
     public save_doc_ingreso_oc: string;
 
+    public dispensacion_no_planificada: string;
+    public recomendar_lotes_multiple: string;
+
 
 
     // user resources (solo autenticacion)
@@ -225,6 +228,8 @@ export default class EndPointsURL{
         this.exportar_inventario_excel = `${domain}/inventario/exportar-excel`;
 
         this.save_doc_ingreso_oc = `${domain}/${movimientos_res}/save_doc_ingreso_oc`;
+        this.dispensacion_no_planificada = `${domain}/${movimientos_res}/dispensacion-no-planificada`;
+        this.recomendar_lotes_multiple = `${domain}/${movimientos_res}/recomendar-lotes-multiple`;
 
         // user endpoints
         this.whoami = `${domain}/${auth_res}/whoami`;

--- a/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/AsistenteDispensacionDirecta.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/AsistenteDispensacionDirecta.tsx
@@ -1,30 +1,16 @@
-import {Box, Container, Flex, Text, Heading, Alert, AlertIcon, AlertTitle, AlertDescription} from '@chakra-ui/react';
+import StepOneComponent from './StepOneComponent';
+import StepTwoComponent from './StepTwoComponent';
+import {useState} from 'react';
+import {DispensacionDirectaDetalleItem} from '../types';
 
-export function AsistenteDispensacionDirecta() {
-    return (
-        <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
-            <Flex direction='column' gap={4} align="center" justify="center" py={10}>
-                <Heading size="lg" color="teal.600">Dispensación Directa</Heading>
-                <Alert 
-                    status="info" 
-                    variant="subtle" 
-                    flexDirection="column" 
-                    alignItems="center" 
-                    justifyContent="center" 
-                    textAlign="center" 
-                    borderRadius="md"
-                    p={6}
-                >
-                    <AlertIcon boxSize="40px" mr={0} />
-                    <AlertTitle mt={4} mb={1} fontSize="lg">
-                        Módulo en Desarrollo
-                    </AlertTitle>
-                    <AlertDescription maxWidth="md">
-                        Esta funcionalidad se encuentra actualmente en desarrollo. 
-                        Pronto estará disponible la dispensación directa de materiales.
-                    </AlertDescription>
-                </Alert>
-            </Flex>
-        </Container>
+export function AsistenteDispensacionDirecta(){
+    const [viewMode, setViewMode] = useState(0);
+    const [dispensacion, setDispensacion] = useState<DispensacionDirectaDetalleItem[]>([]);
+
+    return viewMode === 0 ? (
+        <StepOneComponent setViewMode={setViewMode} setDispensacion={setDispensacion} />
+    ) : (
+        <StepTwoComponent setViewMode={setViewMode} items={dispensacion} setItems={setDispensacion} />
     );
 }
+

--- a/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/StepOneComponent.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/StepOneComponent.tsx
@@ -1,0 +1,85 @@
+import {Box, Button, Flex, Heading, Input, Table, Tbody, Td, Tr, useDisclosure, useToast} from '@chakra-ui/react';
+import MateriaPrimaPicker from '../components/MateriaPrimaPicker';
+import {Material, DispensacionDirectaItem, DispensacionDirectaDetalleItem, DispensacionNoPlanificadaDTO} from '../types';
+import {useState} from 'react';
+import EndPointsURL from '../../../api/EndPointsURL';
+import axios from 'axios';
+
+interface Props {
+    setViewMode: (mode: number) => void;
+    setDispensacion: (items: DispensacionDirectaDetalleItem[]) => void;
+}
+
+export default function StepOneComponent({setViewMode, setDispensacion}: Props){
+    const [items, setItems] = useState<DispensacionDirectaItem[]>([]);
+    const {isOpen, onOpen, onClose} = useDisclosure();
+    const toast = useToast();
+
+    const agregarMateria = (mat: Material) => {
+        if(items.find(it=>it.material.productoId === mat.productoId)) return;
+        setItems([...items, {material: mat, cantidad: 0}]);
+    };
+
+    const handleCantidadChange = (idx:number, value:number) => {
+        const newItems = items.map((it,i)=> i===idx ? {...it, cantidad: value} : it);
+        setItems(newItems);
+    };
+
+    const handleRemove = (idx:number) => {
+        setItems(items.filter((_,i)=>i!==idx));
+    };
+
+    const handleContinuar = async () => {
+        if(items.length === 0){
+            toast({title:'Error', description:'Agregue al menos un material', status:'error', duration:3000, isClosable:true});
+            return;
+        }
+        if(items.some(it=>it.cantidad <= 0)){
+            toast({title:'Error', description:'Las cantidades deben ser mayores a cero', status:'error', duration:3000, isClosable:true});
+            return;
+        }
+        try{
+            const reqItems = items.map(it=>({productoId: it.material.productoId.toString(), cantidad: it.cantidad}));
+            const endpoint = `${EndPointsURL.getDomain()}/movimientos/recomendar-lotes-multiple`;
+            const resp = await axios.post<DispensacionNoPlanificadaDTO>(endpoint, {items: reqItems}, {withCredentials:true});
+            const matMap = new Map(items.map(it=>[it.material.productoId.toString(), it.material]));
+            const detalle: DispensacionDirectaDetalleItem[] = resp.data.items.map(it=>({
+                material: matMap.get(it.productoId)!,
+                loteId: it.loteId ?? null,
+                cantidadSugerida: it.cantidad,
+                cantidad: it.cantidad
+            }));
+            setDispensacion(detalle);
+            setViewMode(1);
+        }catch(err){
+            toast({title:'Error', description:'No se pudo obtener la recomendación de lotes', status:'error', duration:3000, isClosable:true});
+        }
+    };
+
+    return (
+        <Box p='1em' bg='blue.50'>
+            <Flex direction='column' gap={4} align='center'>
+                <Heading fontFamily='Comfortaa Variable'>Agregar Materiales</Heading>
+                <Table size='sm'>
+                    <Tbody>
+                        {items.map((item,idx)=>(
+                            <Tr key={item.material.productoId}>
+                                <Td>{item.material.nombre}</Td>
+                                <Td>
+                                    <Input type='number' value={item.cantidad} onChange={e=>handleCantidadChange(idx, parseFloat(e.target.value))}/>
+                                </Td>
+                                <Td>
+                                    <Button size='sm' onClick={()=>handleRemove(idx)}>Quitar</Button>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+                <Button onClick={onOpen} colorScheme='teal'>Agregar Material</Button>
+                <Button colorScheme='blue' onClick={handleContinuar}>Continuar</Button>
+                <MateriaPrimaPicker isOpen={isOpen} onClose={onClose} onSelectMateriaPrima={agregarMateria}/>
+            </Flex>
+        </Box>
+    );
+}
+

--- a/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/StepTwoComponent.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteDispensacionDirecta/StepTwoComponent.tsx
@@ -1,0 +1,93 @@
+import {Box, Button, Flex, FormControl, FormLabel, Heading, Input, Table, Tbody, Td, Text, Tr, useToast} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import {DispensacionDirectaDetalleItem, DispensacionNoPlanificadaDTO} from '../types';
+import EndPointsURL from '../../../api/EndPointsURL';
+import axios from 'axios';
+import {useAuth} from '../../../context/AuthContext';
+
+interface Props {
+    items: DispensacionDirectaDetalleItem[];
+    setItems: (items: DispensacionDirectaDetalleItem[]) => void;
+    setViewMode: (mode:number)=>void;
+}
+
+export default function StepTwoComponent({items, setItems, setViewMode}: Props){
+    const [token, setToken] = useState('');
+    const [inputToken, setInputToken] = useState('');
+    const [observaciones, setObservaciones] = useState('');
+    const toast = useToast();
+    const { user } = useAuth();
+
+    useEffect(()=>{
+        const t = Math.floor(1000 + Math.random() * 9000).toString();
+        setToken(t);
+        setInputToken('');
+    }, [items]);
+
+    const handleCantidadChange = (idx:number, value:number) => {
+        setItems(items.map((it,i)=> i===idx ? {...it, cantidad:value} : it));
+    };
+
+    const handleLoteChange = (idx:number, value:string) => {
+        setItems(items.map((it,i)=> i===idx ? {...it, loteId: value ? parseInt(value) : null} : it));
+    };
+
+    const enviar = async () => {
+        if(inputToken !== token){
+            toast({title:'Token incorrecto', status:'error', duration:3000, isClosable:true});
+            return;
+        }
+        try{
+            const dto: DispensacionNoPlanificadaDTO = {
+                observaciones,
+                usuarioId: parseInt(user ?? '0'),
+                items: items.map(it=>({productoId: it.material.productoId.toString(), cantidad: it.cantidad, loteId: it.loteId ?? undefined}))
+            };
+            const endpoint = `${EndPointsURL.getDomain()}/movimientos/dispensacion-no-planificada`;
+            await axios.post(endpoint, dto, {withCredentials:true});
+            toast({title:'Dispensación registrada', status:'success', duration:3000, isClosable:true});
+            setViewMode(0);
+            setItems([]);
+        }catch(err){
+            toast({title:'Error al enviar', status:'error', duration:3000, isClosable:true});
+        }
+    };
+
+    return (
+        <Box p='1em' bg='blue.50'>
+            <Flex direction='column' gap={4} align='center'>
+                <Heading fontFamily='Comfortaa Variable'>Revisión de Dispensación</Heading>
+                <Table size='sm'>
+                    <Tbody>
+                        {items.map((item,idx)=>(
+                            <Tr key={idx}>
+                                <Td>{item.material.nombre}</Td>
+                                <Td>
+                                    <Input value={item.loteId ?? ''} onChange={e=>handleLoteChange(idx, e.target.value)} placeholder='Lote'/>
+                                </Td>
+                                <Td>{item.cantidadSugerida}</Td>
+                                <Td>
+                                    <Input type='number' value={item.cantidad} onChange={e=>handleCantidadChange(idx, parseFloat(e.target.value))}/>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </Table>
+                <FormControl w='40%'>
+                    <FormLabel>Observaciones</FormLabel>
+                    <Input value={observaciones} onChange={e=>setObservaciones(e.target.value)} />
+                </FormControl>
+                <FormControl w='40%' isRequired>
+                    <FormLabel>Token de verificación</FormLabel>
+                    <Input value={inputToken} onChange={e=>setInputToken(e.target.value)} placeholder='Ingrese el token'/>
+                </FormControl>
+                <Text fontFamily='Comfortaa Variable'>Token: <strong>{token}</strong></Text>
+                <Flex w='40%' gap={4}>
+                    <Button flex='1' onClick={()=>setViewMode(0)}>Atrás</Button>
+                    <Button flex='1' colorScheme='teal' onClick={enviar} isDisabled={inputToken !== token}>Enviar</Button>
+                </Flex>
+            </Flex>
+        </Box>
+    );
+}
+

--- a/src/pages/TransaccionesAlmacen/components/MateriaPrimaPicker.tsx
+++ b/src/pages/TransaccionesAlmacen/components/MateriaPrimaPicker.tsx
@@ -1,0 +1,246 @@
+// ./MateriaPrimaPicker.tsx
+import React, { useState } from 'react';
+import {
+    Box,
+    Button,
+    FormControl,
+    FormLabel,
+    Input,
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    ModalCloseButton,
+    useToast,
+    VStack,
+    HStack,
+    Text,
+    Select,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    Flex,
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from "../../../api/EndPointsURL";
+import { Material } from '../types';
+
+const endPoints = new EndPointsURL();
+
+interface MateriaPrimaPickerProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSelectMateriaPrima: (materiaPrima: Material) => void;
+}
+
+const MateriaPrimaPicker: React.FC<MateriaPrimaPickerProps> = ({
+                                                                   isOpen,
+                                                                   onClose,
+                                                                   onSelectMateriaPrima,
+                                                               }) => {
+    const [searchText, setSearchText] = useState('');
+    const [tipoBusqueda, setTipoBusqueda] = useState('NOMBRE'); // 'NOMBRE' or 'ID'
+    const [materiasPrimas, setMateriasPrimas] = useState<Material[]>([]);
+    const [selectedMateriaPrimaId, setSelectedMateriaPrimaId] = useState<number | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [currentPage, setCurrentPage] = useState(0); // Backend uses 0-based indexing
+    const [totalPages, setTotalPages] = useState(0);
+    const [, setTotalElements] = useState(0);
+    const size = 10; // Results per page
+    const toast = useToast();
+
+    const handleSearch = async (pageParam?: number) => {
+        setIsLoading(true);
+        try {
+            // Use pageParam if provided, otherwise use currentPage
+            const pageToUse = pageParam !== undefined ? pageParam : currentPage;
+
+            const response = await axios.get(endPoints.search_mprima, {
+                params: { 
+                    search: searchText, 
+                    tipoBusqueda,
+                    page: pageToUse,
+                    size: size
+                },
+            });
+            // Extract pagination information from the response
+            const { content, totalPages: pages, totalElements: elements, number: pageNumber } = response.data;
+
+            // Update state with the new data
+            const updatedMateriasPrimas = content.map((item: Material) => ({
+                ...item,
+                // Optionally adjust properties if needed.
+            }));
+
+            setMateriasPrimas(updatedMateriasPrimas);
+            setTotalPages(pages);
+            setTotalElements(elements);
+            setCurrentPage(pageNumber);
+            setSelectedMateriaPrimaId(null);
+        } catch (error) {
+            console.error('Error searching materias primas:', error);
+            toast({
+                title: 'Error',
+                description: 'Failed to search materias primas.',
+                status: 'error',
+                duration: 5000,
+                isClosable: true,
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleConfirm = () => {
+        if (selectedMateriaPrimaId !== null) {
+            const selectedMateriaPrima = materiasPrimas.find(
+                (p) => p.productoId === selectedMateriaPrimaId
+            );
+            if (selectedMateriaPrima) {
+                onSelectMateriaPrima(selectedMateriaPrima);
+            }
+        }
+        onClose();
+    };
+
+    const handleCancel = () => {
+        onClose();
+    };
+
+    const onKeyPress_InputBuscar = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter' && !isLoading) {
+            setCurrentPage(0); // Reset to first page on new search
+            handleSearch(0); // Pass page 0 explicitly
+        }
+    };
+
+    // Handle pagination
+    const goToPage = (page: number) => {
+        if (page >= 0 && page < totalPages) {
+            setCurrentPage(page);
+            handleSearch(page);  // Pass the page directly to handleSearch
+        }
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} size="lg">
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Seleccionar Materia Prima</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <VStack spacing={4}>
+                        <FormControl>
+                            <FormLabel>Buscar Materia Prima</FormLabel>
+                            <HStack>
+                                <Input
+                                    value={searchText}
+                                    onChange={(e) => setSearchText(e.target.value)}
+                                    onKeyDown={onKeyPress_InputBuscar}
+                                    placeholder="Ingrese nombre o ID"
+                                    isDisabled={isLoading}
+                                />
+                                <Select
+                                    value={tipoBusqueda}
+                                    onChange={(e) => setTipoBusqueda(e.target.value)}
+                                    width="150px"
+                                    isDisabled={isLoading}
+                                >
+                                    <option value="NOMBRE">Nombre</option>
+                                    <option value="ID">ID</option>
+                                </Select>
+                                <Button 
+                                    onClick={() => {
+                                        setCurrentPage(0); // Reset to first page on new search
+                                        handleSearch(0); // Pass page 0 explicitly
+                                    }} 
+                                    isLoading={isLoading}
+                                    loadingText="Buscando"
+                                    colorScheme="blue"
+                                >
+                                    Buscar
+                                </Button>
+                            </HStack>
+                        </FormControl>
+                        <Box w="full" overflowX="auto">
+                            {materiasPrimas.length > 0 ? (
+                                <>
+                                    <Table variant="simple" size="sm">
+                                        <Thead>
+                                            <Tr>
+                                                <Th>ID</Th>
+                                                <Th>Nombre</Th>
+                                                <Th>Categoría</Th>
+                                            </Tr>
+                                        </Thead>
+                                        <Tbody>
+                                            {materiasPrimas.map((materiaPrima) => (
+                                                <Tr 
+                                                    key={materiaPrima.productoId} 
+                                                    onClick={() => setSelectedMateriaPrimaId(materiaPrima.productoId)}
+                                                    bg={selectedMateriaPrimaId === materiaPrima.productoId ? "blue.100" : "transparent"}
+                                                    _hover={{ bg: "gray.100", cursor: "pointer" }}
+                                                >
+                                                    <Td>{materiaPrima.productoId}</Td>
+                                                    <Td>{materiaPrima.nombre}</Td>
+                                                    <Td>{materiaPrima.tipoMaterial === 1 ? "Materia Prima" : "Material de Empaque"}</Td>
+                                                </Tr>
+                                            ))}
+                                        </Tbody>
+                                    </Table>
+
+                                    {/* Pagination controls */}
+                                    {totalPages > 1 && (
+                                        <Flex justifyContent="center" mt={4}>
+                                            <Button 
+                                                size="sm" 
+                                                onClick={() => goToPage(currentPage - 1)} 
+                                                isDisabled={currentPage === 0 || isLoading}
+                                                mr={2}
+                                            >
+                                                Anterior
+                                            </Button>
+                                            <Text alignSelf="center" mx={2}>
+                                                Página {currentPage + 1} de {totalPages}
+                                            </Text>
+                                            <Button 
+                                                size="sm" 
+                                                onClick={() => goToPage(currentPage + 1)} 
+                                                isDisabled={currentPage === totalPages - 1 || isLoading}
+                                                ml={2}
+                                            >
+                                                Siguiente
+                                            </Button>
+                                        </Flex>
+                                    )}
+                                </>
+                            ) : (
+                                <Text textAlign="center">No hay materias primas para mostrar</Text>
+                            )}
+                        </Box>
+                    </VStack>
+                </ModalBody>
+                <ModalFooter>
+                    <Button 
+                        colorScheme="blue" 
+                        mr={3} 
+                        onClick={handleConfirm}
+                        isDisabled={selectedMateriaPrimaId === null}
+                    >
+                        Confirmar
+                    </Button>
+                    <Button variant="ghost" onClick={handleCancel}>
+                        Cancelar
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+};
+
+export default MateriaPrimaPicker;

--- a/src/pages/TransaccionesAlmacen/types.tsx
+++ b/src/pages/TransaccionesAlmacen/types.tsx
@@ -187,3 +187,33 @@ export interface DispensacionDTO {
     ordenProduccionId: number;
     items: ItemDispensacionDTO[];
 }
+
+// ===== Dispensación No Planificada =====
+
+/** Item básico solicitado por el usuario para la dispensación directa */
+export interface DispensacionDirectaItem {
+    material: Material;
+    cantidad: number;
+}
+
+/** Item detallado luego de la recomendación de lotes */
+export interface DispensacionDirectaDetalleItem {
+    material: Material;
+    loteId: number | null;
+    /** Cantidad sugerida por el backend */
+    cantidadSugerida: number;
+    /** Cantidad final a dispensar (editable) */
+    cantidad: number;
+}
+
+export interface DispensacionNoPlanificadaItemDTO {
+    productoId: string;
+    cantidad: number;
+    loteId?: number;
+}
+
+export interface DispensacionNoPlanificadaDTO {
+    observaciones: string;
+    usuarioId: number;
+    items: DispensacionNoPlanificadaItemDTO[];
+}


### PR DESCRIPTION
## Summary
- add endpoints for unplanned material dispensing and lot suggestion
- create two-step wizard for unplanned dispensing with material picker
- allow token-verified submission of suggested lot dispensing

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npx tsc --noEmit` *(fails: Cannot find module '@chakra-ui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0f6ae51c83329ebe012754fc1a52