### PR TITLE
feat: add unplanned backflush interface

### DIFF
--- a/src/api/EndPointsURL.tsx
+++ b/src/api/EndPointsURL.tsx
@@ -74,6 +74,7 @@ export default class EndPointsURL{
     public exportar_inventario_excel: string;
 
     public save_doc_ingreso_oc: string;
+    public backflush_no_planificado: string;
 
 
 
@@ -225,6 +226,7 @@ export default class EndPointsURL{
         this.exportar_inventario_excel = `${domain}/inventario/exportar-excel`;
 
         this.save_doc_ingreso_oc = `${domain}/${movimientos_res}/save_doc_ingreso_oc`;
+        this.backflush_no_planificado = `${domain}/${movimientos_res}/backflush_no_planificado`;
 
         // user endpoints
         this.whoami = `${domain}/${auth_res}/whoami`;

--- a/src/pages/TransaccionesAlmacen/AsistenteBackflushDirecto/AsistenteBackflushDirecto.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteBackflushDirecto/AsistenteBackflushDirecto.tsx
@@ -1,30 +1,158 @@
-import {Box, Container, Flex, Text, Heading, Alert, AlertIcon, AlertTitle, AlertDescription} from '@chakra-ui/react';
+import {useEffect, useState} from 'react';
+import {
+    Box,
+    Button,
+    Container,
+    Flex,
+    Heading,
+    Input,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+    useToast
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../../api/EndPointsURL';
+import TerminadoPicker from './TerminadoPicker';
+import {Almacen, Movimiento, Producto, TipoMovimiento} from '../types';
+
+interface TerminadoSeleccionado {
+    producto: Producto;
+    cantidad: number;
+    lote: string;
+}
 
 export function AsistenteBackflushDirecto() {
+    const [terminados, setTerminados] = useState<TerminadoSeleccionado[]>([]);
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+    const [token, setToken] = useState('');
+    const [inputToken, setInputToken] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const toast = useToast();
+    const endpoints = new EndPointsURL();
+
+    useEffect(() => {
+        const t = Math.floor(1000 + Math.random() * 9000).toString();
+        setToken(t);
+        setInputToken('');
+    }, [terminados]);
+
+    const addTerminados = (prods: Producto[]) => {
+        const nuevos = prods.map(p => ({producto: p, cantidad: 1, lote: ''}));
+        setTerminados(prev => [...prev, ...nuevos]);
+    };
+
+    const updateCantidad = (idx: number, value: number) => {
+        const list = [...terminados];
+        list[idx].cantidad = value;
+        setTerminados(list);
+    };
+
+    const updateLote = (idx: number, value: string) => {
+        const list = [...terminados];
+        list[idx].lote = value;
+        setTerminados(list);
+    };
+
+    const removeItem = (idx: number) => {
+        setTerminados(terminados.filter((_, i) => i !== idx));
+    };
+
+    const datosValidos = terminados.length > 0 && terminados.every(t => t.cantidad > 0 && t.lote.trim() !== '');
+
+    const registrarBackflush = async () => {
+        const movimientos: Movimiento[] = terminados.map(t => ({
+            cantidad: t.cantidad,
+            producto: t.producto,
+            tipoMovimiento: TipoMovimiento.BACKFLUSH,
+            almacen: Almacen.GENERAL,
+            lote: {batchNumber: t.lote, expirationDate: ''},
+            fechaMovimiento: new Date().toISOString()
+        }));
+        try {
+            setIsSubmitting(true);
+            await axios.post(endpoints.backflush_no_planificado, {movimientosTransaccion: movimientos});
+            toast({title: 'Backflush registrado', status: 'success', duration: 3000, isClosable: true});
+            setTerminados([]);
+        } catch (e) {
+            toast({title: 'Error al registrar', status: 'error', duration: 3000, isClosable: true});
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
     return (
-        <Container minW={['auto', 'container.lg', 'container.xl']} w={'full'} h={'full'}>
-            <Flex direction='column' gap={4} align="center" justify="center" py={10}>
-                <Heading size="lg" color="teal.600">Backflush Directo</Heading>
-                <Alert 
-                    status="info" 
-                    variant="subtle" 
-                    flexDirection="column" 
-                    alignItems="center" 
-                    justifyContent="center" 
-                    textAlign="center" 
-                    borderRadius="md"
-                    p={6}
+        <Container minW={['auto', 'container.lg', 'container.xl']} w='full' h='full' py={4}>
+            <Flex direction='column' gap={4}>
+                <Heading size='lg' color='teal.600'>Backflush No Planificado</Heading>
+                <Button alignSelf='flex-start' onClick={() => setIsPickerOpen(true)}>Agregar Terminados</Button>
+                {terminados.length > 0 && (
+                    <Table size='sm'>
+                        <Thead>
+                            <Tr>
+                                <Th>Producto</Th>
+                                <Th>Cantidad</Th>
+                                <Th>Lote</Th>
+                                <Th></Th>
+                            </Tr>
+                        </Thead>
+                        <Tbody>
+                            {terminados.map((t, idx) => (
+                                <Tr key={t.producto.productoId}>
+                                    <Td>{t.producto.nombre}</Td>
+                                    <Td>
+                                        <Input
+                                            type='number'
+                                            value={t.cantidad}
+                                            min={1}
+                                            onChange={e => updateCantidad(idx, parseInt(e.target.value) || 0)}
+                                        />
+                                    </Td>
+                                    <Td>
+                                        <Input
+                                            value={t.lote}
+                                            onChange={e => updateLote(idx, e.target.value)}
+                                        />
+                                    </Td>
+                                    <Td>
+                                        <Button size='xs' colorScheme='red' onClick={() => removeItem(idx)}>-</Button>
+                                    </Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    </Table>
+                )}
+                <Flex direction='column' align='center' gap={2}>
+                    <Input
+                        placeholder='Token'
+                        value={inputToken}
+                        onChange={e => setInputToken(e.target.value)}
+                        w={['full', '40%']}
+                    />
+                    <Box>
+                        Token: <strong>{token}</strong>
+                    </Box>
+                </Flex>
+                <Button
+                    colorScheme='teal'
+                    onClick={registrarBackflush}
+                    isDisabled={!datosValidos || inputToken !== token || isSubmitting}
+                    isLoading={isSubmitting}
+                    loadingText='Enviando'
                 >
-                    <AlertIcon boxSize="40px" mr={0} />
-                    <AlertTitle mt={4} mb={1} fontSize="lg">
-                        Módulo en Desarrollo
-                    </AlertTitle>
-                    <AlertDescription maxWidth="md">
-                        Esta funcionalidad se encuentra actualmente en desarrollo. 
-                        Pronto estará disponible el proceso de backflush directo para productos.
-                    </AlertDescription>
-                </Alert>
+                    Registrar Backflush
+                </Button>
             </Flex>
+            <TerminadoPicker
+                isOpen={isPickerOpen}
+                onClose={() => setIsPickerOpen(false)}
+                onConfirm={addTerminados}
+                alreadySelected={terminados.map(t => t.producto)}
+            />
         </Container>
     );
 }
+

--- a/src/pages/TransaccionesAlmacen/AsistenteBackflushDirecto/TerminadoPicker.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteBackflushDirecto/TerminadoPicker.tsx
@@ -1,0 +1,129 @@
+import {useState, useEffect} from 'react';
+import {
+    Button,
+    Flex,
+    Input,
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    Table,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr
+} from '@chakra-ui/react';
+import axios from 'axios';
+import EndPointsURL from '../../../api/EndPointsURL';
+import {Producto} from '../types';
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: (terminados: Producto[]) => void;
+    alreadySelected: Producto[];
+}
+
+export default function TerminadoPicker({isOpen, onClose, onConfirm, alreadySelected}: Props) {
+    const endpoints = new EndPointsURL();
+    const [searchText, setSearchText] = useState('');
+    const [available, setAvailable] = useState<Producto[]>([]);
+    const [selected, setSelected] = useState<Producto[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    const fetchTerminados = async () => {
+        setLoading(true);
+        try {
+            const res = await axios.get(endpoints.search_terminado_byname, {
+                params: {search: searchText}
+            });
+            let list: Producto[] = res.data.content || res.data;
+            const ids = new Set([...alreadySelected, ...selected].map(p => p.productoId));
+            list = list.filter(p => !ids.has(p.productoId));
+            setAvailable(list);
+        } catch (e) {
+            setAvailable([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (isOpen) fetchTerminados();
+    }, [isOpen]);
+
+    const handleAdd = (p: Producto) => {
+        setSelected([...selected, p]);
+        setAvailable(available.filter(a => a.productoId !== p.productoId));
+    };
+
+    const handleRemove = (p: Producto) => {
+        setSelected(selected.filter(a => a.productoId !== p.productoId));
+        setAvailable([...available, p]);
+    };
+
+    const handleAccept = () => {
+        onConfirm(selected);
+        setSelected([]);
+        setAvailable([]);
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} size="5xl">
+            <ModalOverlay/>
+            <ModalContent>
+                <ModalHeader>Seleccionar Terminados</ModalHeader>
+                <ModalCloseButton/>
+                <ModalBody>
+                    <Flex mb={2} gap={2}>
+                        <Input
+                            placeholder='Buscar'
+                            value={searchText}
+                            onChange={e => setSearchText(e.target.value)}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') fetchTerminados();
+                            }}
+                        />
+                        <Button onClick={fetchTerminados} isLoading={loading} loadingText='Buscando'>Buscar</Button>
+                    </Flex>
+                    <Flex gap={4}>
+                        <Table size='sm'>
+                            <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                            <Tbody>
+                            {available.map(p => (
+                                <Tr key={p.productoId}>
+                                    <Td>{p.productoId}</Td>
+                                    <Td>{p.nombre}</Td>
+                                    <Td><Button size='xs' onClick={() => handleAdd(p)}>+</Button></Td>
+                                </Tr>
+                            ))}
+                            </Tbody>
+                        </Table>
+                        <Table size='sm'>
+                            <Thead><Tr><Th>ID</Th><Th>Nombre</Th><Th></Th></Tr></Thead>
+                            <Tbody>
+                            {selected.map(p => (
+                                <Tr key={p.productoId}>
+                                    <Td>{p.productoId}</Td>
+                                    <Td>{p.nombre}</Td>
+                                    <Td><Button size='xs' colorScheme='red' onClick={() => handleRemove(p)}>-</Button></Td>
+                                </Tr>
+                            ))}
+                            </Tbody>
+                        </Table>
+                    </Flex>
+                </ModalBody>
+                <ModalFooter>
+                    <Button mr={3} onClick={onClose}>Cancelar</Button>
+                    <Button colorScheme='teal' onClick={handleAccept}>Aceptar</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add endpoint config for unplanned backflush
- implement backflush UI with terminado picker, quantities, lots and token validation
- create terminado picker modal to search and select finished products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12e7413c83328e86576bf8d18d39