### PR TITLE
refactor: use Modulo enum for module notifications

### DIFF
--- a/src/api/ModulesNotifications.tsx
+++ b/src/api/ModulesNotifications.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import EndPointsURL from './EndPointsURL';
 import { useAuth } from '../context/AuthContext';
+import { Modulo } from '../pages/Usuarios/GestionUsuarios/types.tsx';
 
 export interface ModuleNotificationDTA {
-    modulo: string;
+    modulo: Modulo;
     requireAtention: boolean;
     message: string;
 }
@@ -32,10 +33,6 @@ export function useModuleNotifications() {
                 // Llamar al endpoint real con el username como parámetro
                 const response = await axios.get(url);
 //                 console.log('fetchNotifications - Respuesta:', response.data); // Log de la respuesta
-
-                // Verificar si hay notificación para COMPRAS
-                const comprasNotification = response.data.find((n: ModuleNotificationDTA) => n.modulo === 'COMPRAS');
-//                 console.log('fetchNotifications - Notificación COMPRAS:', comprasNotification);
 
                 setNotifications(response.data);
             } else {

--- a/src/context/NotificationsContext.tsx
+++ b/src/context/NotificationsContext.tsx
@@ -1,12 +1,13 @@
-import React, { createContext, useContext, ReactNode, useEffect } from 'react';
+import React, { createContext, useContext, ReactNode } from 'react';
 import { ModuleNotificationDTA, useModuleNotifications } from '../api/ModulesNotifications';
+import { Modulo } from '../pages/Usuarios/GestionUsuarios/types.tsx';
 
 interface NotificationsContextType {
     notifications: ModuleNotificationDTA[];
     loading: boolean;
     error: string | null;
     refreshNotifications: () => void;
-    getNotificationForModule: (moduleName: string) => ModuleNotificationDTA | undefined;
+    getNotificationForModule: (moduleName: Modulo) => ModuleNotificationDTA | undefined;
 }
 
 const NotificationsContext = createContext<NotificationsContextType | undefined>(undefined);
@@ -15,15 +16,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
 //     console.log('NotificationsProvider - Inicializando contexto');
     const notificationsData = useModuleNotifications();
 
-    useEffect(() => {
-//         console.log('NotificationsContext - Notificaciones actualizadas:', notificationsData.notifications);
-        // Verificar específicamente la notificación de COMPRAS
-        const comprasNotification = notificationsData.notifications.find(n => n.modulo === 'COMPRAS');
-//         console.log('NotificationsContext - Notificación COMPRAS:', comprasNotification);
-    }, [notificationsData.notifications]);
-
     // Función para obtener la notificación correspondiente a un módulo
-    const getNotificationForModule = (moduleName: string): ModuleNotificationDTA | undefined => {
+    const getNotificationForModule = (moduleName: Modulo): ModuleNotificationDTA | undefined => {
 //         console.log(`getNotificationForModule - Buscando notificación para: ${moduleName}`);
 
         const notification = notificationsData.notifications.find(

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -29,7 +29,6 @@ import { MdRefresh } from "react-icons/md"; // Icono para el botón de actualiza
 import '@fontsource-variable/comfortaa'
 
 import { Modulo } from "./Usuarios/GestionUsuarios/types.tsx";
-import { ModuleNotificationDTA } from "../api/ModulesNotifications.tsx";
 
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/NotificationsContext';
@@ -44,9 +43,6 @@ export default function Home(){
     // Get the getNotificationForModule function from the notifications context
     const { getNotificationForModule, refreshNotifications } = useNotifications();
 
-    // Log específico para la notificación de COMPRAS
-    const comprasNotification = getNotificationForModule('COMPRAS');
-//     console.log('Home - Notificación COMPRAS:', comprasNotification);
 
     return (
         <Container minW={['auto', 'container.lg', 'container.xl']}>
@@ -117,13 +113,13 @@ export default function Home(){
                 <SectionCard to={'/clientes'} name={'Clientes'} icon={FaUsers} supportedModules={[Modulo.CLIENTES]} currentAccesos={roles} notification={getNotificationForModule(Modulo.CLIENTES)}/>
                 <SectionCard to={'/ventas'} name={'Ventas'} icon={FaShoppingCart} supportedModules={[Modulo.VENTAS]} currentAccesos={roles} notification={getNotificationForModule(Modulo.VENTAS)}/>
                 <SectionCard to={'/transacciones_almacen'} name={'Transacciones de Almacen'} icon={MdWarehouse} supportedModules={[Modulo.TRANSACCIONES_ALMACEN]} currentAccesos={roles} notification={getNotificationForModule(Modulo.TRANSACCIONES_ALMACEN)}/>
-                <SectionCard to={'/carga_masiva'} name={'Carga Masiva de Datos'} icon={FaFileUpload} supportedModules={[]} currentAccesos={roles} bgColor="red.100" notification={getNotificationForModule('CARGA_MASIVA')}/>
+                <SectionCard to={'/carga_masiva'} name={'Carga Masiva de Datos'} icon={FaFileUpload} supportedModules={[]} currentAccesos={roles} bgColor="red.100" notification={getNotificationForModule('CARGA_MASIVA' as Modulo)}/>
                 <SectionCard to={'/Activos'} name={'Activos Fijos'} icon={FaSteam} supportedModules={[Modulo.ACTIVOS]} currentAccesos={roles} notification={getNotificationForModule(Modulo.ACTIVOS)}/>
                 <SectionCard to={'/Contabilidad'} name={'Contabilidad'} icon={TbReportMoney} supportedModules={[Modulo.CONTABILIDAD]} currentAccesos={roles} notification={getNotificationForModule(Modulo.CONTABILIDAD)}/>
                 <SectionCard to={'/Personal'} name={'Personal'} icon={PiMicrosoftTeamsLogoFill} supportedModules={[Modulo.PERSONAL_PLANTA]} currentAccesos={roles} notification={getNotificationForModule(Modulo.PERSONAL_PLANTA)}/>
                 <SectionCard to={'/Bintelligence'} name={'BI'} icon={MdOutlineInsights} supportedModules={[Modulo.BINTELLIGENCE]} currentAccesos={roles} notification={getNotificationForModule(Modulo.BINTELLIGENCE)}/>
                 <SectionCard to={'/administracion_alertas'} name={'Administracion Alertas'} icon={MdNotificationsActive} supportedModules={[Modulo.ADMINISTRACION_ALERTAS]} currentAccesos={roles} notification={getNotificationForModule(Modulo.ADMINISTRACION_ALERTAS)}/>
-                <SectionCard to={'/master_directives'} name={'Master Directives'} icon={FaCogs} supportedModules={[]} currentAccesos={roles} bgColor="red.100" notification={getNotificationForModule('MASTER_CONFIGS')}/>
+                <SectionCard to={'/master_directives'} name={'Master Directives'} icon={FaCogs} supportedModules={[]} currentAccesos={roles} bgColor="red.100" notification={getNotificationForModule('MASTER_CONFIGS' as Modulo)}/>
                 <SectionCard to={'/cronograma'} name={'Cronograma'} icon={FaCalendarAlt} supportedModules={[Modulo.CRONOGRAMA]} currentAccesos={roles} notification={getNotificationForModule(Modulo.CRONOGRAMA)}/>
                 <SectionCard to={'/organigrama'} name={'Organigrama'} icon={FaSitemap} supportedModules={[Modulo.ORGANIGRAMA]} currentAccesos={roles} notification={getNotificationForModule(Modulo.ORGANIGRAMA)}/>
                 <SectionCard to={'/pagos-proveedores'} name={'Pagos a Proveedores'} icon={FaMoneyBillWave} supportedModules={[Modulo.PAGOS_PROVEEDORES]} currentAccesos={roles} notification={getNotificationForModule(Modulo.PAGOS_PROVEEDORES)}/>


### PR DESCRIPTION
## Summary
- use `Modulo` enum in module notification interface
- clean up unused imports and variables in Home
- expose `getNotificationForModule` with `Modulo`-typed parameter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2c6023c8833286f27385f11a89e5