### PR TITLE
Integrate material deletion with backend

### DIFF
--- a/src/pages/Productos/DefSemiTer/consulta/DeleteProductoDialog.tsx
+++ b/src/pages/Productos/DefSemiTer/consulta/DeleteProductoDialog.tsx
@@ -1,0 +1,67 @@
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalBody,
+    ModalFooter,
+    Button,
+    Text,
+    Input,
+} from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+interface DeleteProductoDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+}
+
+export default function DeleteProductoDialog({ isOpen, onClose, onConfirm }: DeleteProductoDialogProps) {
+    const [randomCode, setRandomCode] = useState('');
+    const [inputCode, setInputCode] = useState('');
+
+    useEffect(() => {
+        if (isOpen) {
+            setRandomCode(Math.floor(1000 + Math.random() * 9000).toString());
+            setInputCode('');
+        }
+    }, [isOpen]);
+
+    const handleConfirm = async () => {
+        await onConfirm();
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>Confirmar Eliminación</ModalHeader>
+                <ModalBody>
+                    <Text mb={4}>
+                        Para confirmar la eliminación del producto, ingrese el siguiente código:
+                    </Text>
+                    <Text fontWeight="bold" mb={4}>Código: {randomCode}</Text>
+                    <Input
+                        placeholder="Ingrese el código aquí"
+                        value={inputCode}
+                        onChange={(e) => setInputCode(e.target.value)}
+                    />
+                </ModalBody>
+                <ModalFooter>
+                    <Button
+                        colorScheme="red"
+                        mr={3}
+                        onClick={handleConfirm}
+                        isDisabled={inputCode !== randomCode}
+                    >
+                        Eliminar
+                    </Button>
+                    <Button variant="ghost" onClick={onClose}>Cancelar</Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+}
+


### PR DESCRIPTION
## Summary
- restrict delete button to materials in edit mode
- add modal-confirmed deletion request to backend with conflict handling
- allow delete dialog to await async confirmation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a37c2d6c83328da8f6eb21129879