### PR TITLE
feat: add producto terminado card component

### DIFF
--- a/src/pages/Produccion/CrearOrdenes.tsx
+++ b/src/pages/Produccion/CrearOrdenes.tsx
@@ -1,21 +1,12 @@
 // src/pages/ProduccionPage/CrearOrdenes.tsx
 
 import { useState } from 'react';
-import {
-    Textarea,
-    Select,
-    Button,
-    VStack,
-    Card,
-    CardHeader,
-    CardBody,
-    Heading,
-    Text,
-} from '@chakra-ui/react';
+import { Textarea, Select, Button, VStack } from '@chakra-ui/react';
 import axios from 'axios';
 import { useToast } from '@chakra-ui/react';
-import {ProductoWithInsumos} from "./types.tsx";
-import EndPointsURL from "../../api/EndPointsURL.tsx";
+import { ProductoWithInsumos } from './types.tsx';
+import EndPointsURL from '../../api/EndPointsURL.tsx';
+import ProductoTerminadoCard from './components/ProductoTerminadoCard';
 
 const endPoints = new EndPointsURL();
 
@@ -80,23 +71,10 @@ export default function CrearOrdenes() {
 
     return (
         <VStack align="stretch">
-            <Card>
-                <CardHeader>
-                    <Heading size="md">Producto terminado</Heading>
-                </CardHeader>
-                <CardBody>
-                    <VStack align="stretch" spacing={4}>
-                        <Text>
-                            {selectedProducto
-                                ? `Seleccionado: ${selectedProducto.producto.nombre}`
-                                : 'Ningún producto seleccionado.'}
-                        </Text>
-                        <Button colorScheme="blue" onClick={handleSeleccionarProducto}>
-                            Seleccionar producto terminado
-                        </Button>
-                    </VStack>
-                </CardBody>
-            </Card>
+            <ProductoTerminadoCard
+                selectedProducto={selectedProducto}
+                onPickClick={handleSeleccionarProducto}
+            />
             <Textarea
                 placeholder="Observaciones"
                 value={observaciones}

--- a/src/pages/Produccion/components/ProductoTerminadoCard.tsx
+++ b/src/pages/Produccion/components/ProductoTerminadoCard.tsx
@@ -1,0 +1,123 @@
+import {
+    Badge,
+    Button,
+    Card,
+    CardBody,
+    CardHeader,
+    HStack,
+    IconButton,
+    Tag,
+    Text,
+    VStack,
+    Heading,
+} from '@chakra-ui/react';
+import { SearchIcon } from '@chakra-ui/icons';
+import { ProductoWithInsumos } from '../types';
+
+interface ProductoTerminadoCardProps {
+    selectedProducto: ProductoWithInsumos | null;
+    onPickClick: () => void;
+}
+
+const ProductoTerminadoCard = ({
+    selectedProducto,
+    onPickClick,
+}: ProductoTerminadoCardProps) => {
+    const topInsumos = selectedProducto?.insumos.slice(0, 3) ?? [];
+
+    return (
+        <Card>
+            <CardHeader>
+                <HStack justify="space-between" align="flex-start">
+                    <VStack align="flex-start" spacing={1}>
+                        <Heading size="md">
+                            {selectedProducto
+                                ? selectedProducto.producto.nombre
+                                : 'Seleccionar terminado/semiterminado'}
+                        </Heading>
+                        <Text fontSize="sm" color="gray.500">
+                            {selectedProducto
+                                ? `Código: ${selectedProducto.producto.productoId}`
+                                : 'Elige un producto terminado o semiterminado para crear la orden.'}
+                        </Text>
+                    </VStack>
+                    {selectedProducto ? (
+                        <IconButton
+                            aria-label="Cambiar producto"
+                            icon={<SearchIcon />}
+                            variant="ghost"
+                            colorScheme="blue"
+                            onClick={onPickClick}
+                        />
+                    ) : (
+                        <IconButton
+                            aria-label="Seleccionar producto"
+                            icon={<SearchIcon />}
+                            variant="outline"
+                            colorScheme="blue"
+                            onClick={onPickClick}
+                        />
+                    )}
+                </HStack>
+            </CardHeader>
+            <CardBody>
+                {selectedProducto ? (
+                    <VStack align="stretch" spacing={4}>
+                        <HStack spacing={2}>
+                            <Tag colorScheme="purple">{selectedProducto.producto.tipo_producto}</Tag>
+                            <Tag colorScheme="blue">
+                                {selectedProducto.producto.cantidadUnidad}{' '}
+                                {selectedProducto.producto.tipoUnidades}
+                            </Tag>
+                        </HStack>
+                        <VStack align="stretch" spacing={3}>
+                            <Heading size="sm">Insumos destacados</Heading>
+                            {topInsumos.length === 0 ? (
+                                <Text fontSize="sm" color="gray.500">
+                                    Este producto no tiene insumos asociados.
+                                </Text>
+                            ) : (
+                                topInsumos.map((insumo) => {
+                                    const tieneStockSuficiente = insumo.stockActual >= insumo.cantidadRequerida;
+                                    return (
+                                        <HStack
+                                            key={`${insumo.insumoId}-${insumo.productoId}`}
+                                            justify="space-between"
+                                            align="flex-start"
+                                        >
+                                            <VStack align="flex-start" spacing={0}>
+                                                <Text fontWeight="medium">{insumo.productoNombre}</Text>
+                                                <Text fontSize="xs" color="gray.500">
+                                                    Requerido: {insumo.cantidadRequerida}
+                                                </Text>
+                                            </VStack>
+                                            <Badge colorScheme={tieneStockSuficiente ? 'green' : 'red'}>
+                                                Stock: {insumo.stockActual}
+                                            </Badge>
+                                        </HStack>
+                                    );
+                                })
+                            )}
+                            {selectedProducto.insumos.length > 3 && (
+                                <Text fontSize="xs" color="gray.500">
+                                    +{selectedProducto.insumos.length - 3} insumos adicionales
+                                </Text>
+                            )}
+                        </VStack>
+                    </VStack>
+                ) : (
+                    <VStack align="stretch" spacing={4}>
+                        <Text color="gray.600">
+                            No hay un producto seleccionado actualmente. Usa el buscador para elegir el terminado o semiterminado adecuado.
+                        </Text>
+                        <Button leftIcon={<SearchIcon />} colorScheme="blue" onClick={onPickClick} alignSelf="flex-start">
+                            Buscar producto
+                        </Button>
+                    </VStack>
+                )}
+            </CardBody>
+        </Card>
+    );
+};
+
+export default ProductoTerminadoCard;


### PR DESCRIPTION
## Summary
- add a ProductoTerminadoCard component with empty and selected states, tags, and stock highlights
- integrate the new component into the CrearOrdenes flow to replace the inline card

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c9eaf248332b13d0642f0061c45