### PR TITLE
feat: add terminado card component for production orders

### DIFF
--- a/src/pages/Produccion/CrearOrdenes.tsx
+++ b/src/pages/Produccion/CrearOrdenes.tsx
@@ -6,21 +6,13 @@ import {
     Select,
     Button,
     VStack,
-    Card,
-    CardHeader,
-    CardBody,
-    Heading,
-    Text,
-    Box,
-    Divider,
-    Flex,
-    Tag,
     useToast,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import {ProductoWithInsumos} from "./types";
 import EndPointsURL from "../../api/EndPointsURL";
 import TerminadoSemiterminadoPicker from "./components/TerminadoSemiterminadoPicker";
+import TerSemiTerCard from "./components/TerSemiTerCard";
 
 const endPoints = new EndPointsURL();
 
@@ -83,62 +75,14 @@ export default function CrearOrdenes() {
 
     return (
         <VStack align="stretch">
-            <Card>
-                <CardHeader>
-                    <Heading size="md">Producto terminado</Heading>
-                </CardHeader>
-                <CardBody>
-                    <VStack align="stretch" spacing={4}>
-                        {selectedProducto ? (
-                            <VStack align='stretch' spacing={2}>
-                                <Heading size='sm'>{selectedProducto.producto.nombre}</Heading>
-                                <Text fontSize='sm' color='gray.600'>ID: {selectedProducto.producto.productoId}</Text>
-                                <Divider/>
-                                <VStack align='stretch' spacing={2}>
-                                    <Text fontWeight='medium'>Insumos requeridos</Text>
-                                    {selectedProducto.insumos.length === 0 ? (
-                                        <Text fontSize='sm' color='gray.500'>No se registran insumos para este producto.</Text>
-                                    ) : (
-                                        selectedProducto.insumos.map(insumo => {
-                                            const tieneStock = insumo.stockActual >= insumo.cantidadRequerida;
-                                            return (
-                                                <Flex
-                                                    key={insumo.insumoId}
-                                                    justify='space-between'
-                                                    align='center'
-                                                    p={2}
-                                                    borderWidth='1px'
-                                                    borderRadius='md'
-                                                    borderColor={tieneStock ? 'green.200' : 'red.200'}
-                                                    bg={tieneStock ? 'green.50' : 'red.50'}
-                                                >
-                                                    <Box>
-                                                        <Text fontSize='sm' fontWeight='medium'>{insumo.productoNombre}</Text>
-                                                        <Text fontSize='xs' color='gray.600'>Requerido: {insumo.cantidadRequerida}</Text>
-                                                    </Box>
-                                                    <Tag colorScheme={tieneStock ? 'green' : 'red'}>
-                                                        Stock: {insumo.stockActual}
-                                                    </Tag>
-                                                </Flex>
-                                            );
-                                        })
-                                    )}
-                                </VStack>
-                                <Text fontWeight='medium' color={canProduce ? 'green.600' : 'red.600'}>
-                                    {canProduce
-                                        ? 'Stock suficiente para producir este producto.'
-                                        : 'Stock insuficiente en al menos un insumo.'}
-                                </Text>
-                            </VStack>
-                        ) : (
-                            <Text>Ningún producto seleccionado.</Text>
-                        )}
-                        <Button colorScheme="blue" onClick={handleSeleccionarProducto}>
-                            Seleccionar producto terminado
-                        </Button>
-                    </VStack>
-                </CardBody>
-            </Card>
+            <TerSemiTerCard
+                productoSeleccionado={selectedProducto}
+                canProduce={canProduce}
+                onSearchClick={handleSeleccionarProducto}
+            />
+            <Button colorScheme="blue" onClick={handleSeleccionarProducto}>
+                Seleccionar producto terminado
+            </Button>
             <Textarea
                 placeholder="Observaciones"
                 value={observaciones}

--- a/src/pages/Produccion/components/TerSemiTerCard.tsx
+++ b/src/pages/Produccion/components/TerSemiTerCard.tsx
@@ -1,0 +1,118 @@
+import {
+    Card,
+    CardHeader,
+    HStack,
+    IconButton,
+    Heading,
+    Divider,
+    CardBody,
+    VStack,
+    Text,
+    Flex,
+    Box,
+    Tag,
+} from '@chakra-ui/react';
+import { FaSearch } from 'react-icons/fa';
+import { ProductoWithInsumos } from '../types';
+
+interface TerSemiTerCardProps {
+    productoSeleccionado: ProductoWithInsumos | null;
+    canProduce: boolean;
+    onSearchClick: () => void;
+}
+
+const TerSemiTerCard = ({ productoSeleccionado, canProduce, onSearchClick }: TerSemiTerCardProps) => {
+    const producto = productoSeleccionado?.producto;
+    const insumos = productoSeleccionado?.insumos ?? [];
+
+    return (
+        <Card variant="outline" borderColor="blue.200" w="full">
+            <CardHeader bg="blue.50">
+                <HStack>
+                    <IconButton
+                        aria-label="Buscar terminado o semiterminado"
+                        icon={<FaSearch />}
+                        onClick={onSearchClick}
+                    />
+                    <Heading size="sm">
+                        {producto ? producto.nombre : 'Selecciona un terminado/semiterminado'}
+                    </Heading>
+                </HStack>
+            </CardHeader>
+            <Divider />
+            <CardBody>
+                {producto ? (
+                    <VStack align="stretch" spacing={4}>
+                        <VStack align="start" spacing={1}>
+                            <Text fontSize="sm" fontWeight="medium">
+                                Nombre: {producto.nombre}
+                            </Text>
+                            <Text fontSize="sm" color="gray.600">
+                                ID: {producto.productoId}
+                            </Text>
+                            <Text fontSize="sm" color="gray.600">
+                                Tipo: {producto.tipo_producto}
+                            </Text>
+                            <Text fontSize="sm" color="gray.600">
+                                Unidad: {producto.tipoUnidades}
+                            </Text>
+                        </VStack>
+                        <Divider />
+                        <VStack align="stretch" spacing={2}>
+                            <Text fontWeight="medium">Insumos requeridos</Text>
+                            {insumos.length === 0 ? (
+                                <Text fontSize="sm" color="gray.500">
+                                    No se registran insumos para este producto.
+                                </Text>
+                            ) : (
+                                insumos.map((insumo) => {
+                                    const tieneStock = insumo.stockActual >= insumo.cantidadRequerida;
+                                    return (
+                                        <Flex
+                                            key={insumo.insumoId}
+                                            justify="space-between"
+                                            align="center"
+                                            p={2}
+                                            borderWidth="1px"
+                                            borderRadius="md"
+                                            borderColor={tieneStock ? 'green.200' : 'red.200'}
+                                            bg={tieneStock ? 'green.50' : 'red.50'}
+                                        >
+                                            <Box>
+                                                <Text fontSize="sm" fontWeight="medium">
+                                                    {insumo.productoNombre}
+                                                </Text>
+                                                <Text fontSize="xs" color="gray.600">
+                                                    Requerido: {insumo.cantidadRequerida}
+                                                </Text>
+                                            </Box>
+                                            <Tag colorScheme={tieneStock ? 'green' : 'red'}>
+                                                Stock: {insumo.stockActual}
+                                            </Tag>
+                                        </Flex>
+                                    );
+                                })
+                            )}
+                        </VStack>
+                        <Text fontWeight="medium" color={canProduce ? 'green.600' : 'red.600'}>
+                            {canProduce
+                                ? 'Stock suficiente para producir este producto.'
+                                : 'Stock insuficiente en al menos un insumo.'}
+                        </Text>
+                    </VStack>
+                ) : (
+                    <VStack align="stretch" spacing={3}>
+                        <Text fontSize="sm" color="gray.600">
+                            Aún no se ha seleccionado un producto terminado o semiterminado.
+                        </Text>
+                        <Text fontSize="sm" color="gray.500">
+                            Usa el botón de búsqueda para elegir un producto y ver sus detalles e insumos requeridos.
+                        </Text>
+                    </VStack>
+                )}
+            </CardBody>
+        </Card>
+    );
+};
+
+export default TerSemiTerCard;


### PR DESCRIPTION
## Summary
- add a reusable card to show terminado/semiterminado details with stock status
- reuse the new card in CrearOrdenes to avoid duplicated markup and trigger the picker from the header icon

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4297150f08332bbf15fbba1ec079b