### PR TITLE
Set default date range on step zero component

### DIFF
--- a/src/pages/TransaccionesAlmacen/AsistenteIngresoOCM/StepZeroComponent_v2.tsx
+++ b/src/pages/TransaccionesAlmacen/AsistenteIngresoOCM/StepZeroComponent_v2.tsx
@@ -41,8 +41,12 @@ export default function StepZeroComponent_v2({
     const endpoints = useMemo(() => new EndPointsURL(), []);
     const [isLoading, setIsLoading] = useState(false);
     const [proveedor, setProveedor] = useState<Proveedor | null>(null);
-    const [fechaInicio, setFechaInicio] = useState<string>("");
-    const [fechaFin, setFechaFin] = useState<string>("");
+    const [fechaInicio, setFechaInicio] = useState<string>(() => {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        return yesterday.toISOString().split("T")[0];
+    });
+    const [fechaFin, setFechaFin] = useState<string>(() => new Date().toISOString().split("T")[0]);
     const [ordenes, setOrdenes] = useState<OrdenCompra[]>([]);
 
     const { isOpen, onOpen, onClose } = useDisclosure();


### PR DESCRIPTION
## Summary
- set default date filters in StepZeroComponent_v2 to yesterday and today using formatted strings
- ensure date inputs display these defaults on initial render

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b2be8e908332bfffdc0af4825692)